### PR TITLE
Expand trading agents with market, sentiment and news analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
+# AI Trading Agent
 
+This repository contains the beginnings of an agent-based trading framework.  It
+is intentionally lightweight and serves as a foundation for future work.  The
+project structure includes:
+
+- **TechnicalAnalysisAgent** – downloads price data from Yahoo Finance and
+  computes a few common indicators (EMA, RSI and MACD).
+- **MarketScannerAgent** – collects price, volume, VWAP, ATR and volatility
+  metrics.
+- **SocialMediaAgent** – performs keyword based sentiment analysis on a small
+  sample of posts.
+- **NewsAnalyzerAgent** – analyses sample headlines for sentiment.
+- **Strategy Composer** – combines the outputs of agents into a single trading
+  strategy dictionary containing entry, sizing and risk guidelines.
+- **Backtester** – runs a minimal buy-and-hold simulation to evaluate a
+  composed strategy.
+
+The implementation is heavily simplified but follows the JSON schemas described
+in the project specification.
+
+## Running tests
+
+The repository uses `pytest` for the tiny test-suite.  To execute the tests run:
+
+```bash
+pytest
+```
+
+Network access is not required for the tests as external data calls are
+mocked.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from unittest.mock import patch
+
+from trading_bot.backtest import Backtester
+
+
+def test_backtester_returns_structure():
+    dates = pd.date_range("2024-01-01", periods=5)
+    df = pd.DataFrame({"Close": pd.Series([1, 2, 3, 4, 5], index=dates)})
+
+    with patch("yfinance.download", return_value=df):
+        bt = Backtester()
+        strategy = {"symbol": "TSLA"}
+        result = bt.backtest("TSLA", "2024-01-01", "2024-01-05", strategy)
+
+    assert result["symbol"] == "TSLA"
+    assert "net_return" in result and result["net_return"] > 0
+    assert result["trade_log"][0]["entry_price"] == 1

--- a/tests/test_market_scanner_agent.py
+++ b/tests/test_market_scanner_agent.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from unittest.mock import patch
+
+from trading_bot.agents.market_scanner import MarketScannerAgent
+
+
+def test_market_scanner_returns_expected_structure():
+    dates = pd.date_range("2024-01-01", periods=30)
+    df = pd.DataFrame(
+        {
+            "Close": pd.Series(range(1, 31), index=dates),
+            "Volume": pd.Series(1000, index=dates),
+            "High": pd.Series(range(2, 32), index=dates),
+            "Low": pd.Series(range(0, 30), index=dates),
+        }
+    )
+
+    with patch("yfinance.download", return_value=df):
+        agent = MarketScannerAgent()
+        result = agent.analyze("TSLA")
+
+    assert result["agent"] == "MarketScannerAgent"
+    assert result["symbol"] == "TSLA"
+    assert {"price", "volume", "vwap", "atr_14", "volatility"} <= set(
+        result["results"].keys()
+    )

--- a/tests/test_social_news_agents.py
+++ b/tests/test_social_news_agents.py
@@ -1,0 +1,16 @@
+from trading_bot.agents.social_media import SocialMediaAgent
+from trading_bot.agents.news_analyzer import NewsAnalyzerAgent
+
+
+def test_social_media_agent_structure():
+    agent = SocialMediaAgent()
+    result = agent.analyze("TSLA")
+    assert result["agent"] == "SocialMediaAgent"
+    assert "score" in result
+
+
+def test_news_analyzer_agent_structure():
+    agent = NewsAnalyzerAgent()
+    result = agent.analyze("TSLA")
+    assert result["agent"] == "NewsAnalyzerAgent"
+    assert "sentiment" in result

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,29 @@
+from trading_bot.strategy import compose_strategy
+
+
+def test_compose_strategy_structure():
+    technical = {"summary": "Bullish"}
+    market = {"summary": ""}
+    news = {"summary": "", "headlines": []}
+    social = {"summary": "", "score": 0}
+    macro = {"summary": ""}
+    strategy = compose_strategy(
+        symbol="TSLA",
+        technical=technical,
+        market=market,
+        news=news,
+        social=social,
+        macro=macro,
+        strategy_date="2024-01-01",
+    )
+
+    assert strategy["symbol"] == "TSLA"
+    for key in [
+        "entry_criteria",
+        "position_sizing",
+        "risk_management",
+        "exit_strategy",
+        "trade_management",
+    ]:
+        assert key in strategy
+    assert "rationale" in strategy and "market" in strategy["rationale"]

--- a/tests/test_technical_analysis_agent.py
+++ b/tests/test_technical_analysis_agent.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from unittest.mock import patch
+
+from trading_bot.agents.technical_analysis import TechnicalAnalysisAgent
+
+
+def test_analyze_returns_expected_structure():
+    # Create deterministic price series so indicator values are stable
+    close = pd.Series(range(1, 31), index=pd.date_range("2024-01-01", periods=30))
+    df = pd.DataFrame({"Close": close})
+
+    with patch("yfinance.download", return_value=df):
+        agent = TechnicalAnalysisAgent()
+        result = agent.analyze("TSLA")
+
+    assert result["agent"] == "TechnicalAnalysisAgent"
+    assert result["symbol"] == "TSLA"
+    assert set(result["indicators_used"]) == {"ema_9", "rsi_14", "macd_hist"}
+    assert {"ema_9", "rsi_14", "macd_hist"} <= result["results"].keys()
+    assert result["trend_signal"] in {"bullish", "bearish"}

--- a/trading_bot/agents/__init__.py
+++ b/trading_bot/agents/__init__.py
@@ -1,0 +1,14 @@
+"""Agents package exposes available agent classes."""
+
+from .technical_analysis import TechnicalAnalysisAgent
+from .market_scanner import MarketScannerAgent
+from .social_media import SocialMediaAgent
+from .news_analyzer import NewsAnalyzerAgent
+
+__all__ = [
+    "TechnicalAnalysisAgent",
+    "MarketScannerAgent",
+    "SocialMediaAgent",
+    "NewsAnalyzerAgent",
+]
+

--- a/trading_bot/agents/market_scanner.py
+++ b/trading_bot/agents/market_scanner.py
@@ -1,0 +1,78 @@
+"""Market scanner agent for basic market metrics.
+
+This agent fetches recent price data via :mod:`yfinance` and extracts a
+handful of metrics that are typically used to gauge the current market
+environment for a given symbol.  The implementation is intentionally
+lightweight but follows the structured output format described in the project
+specification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class MarketScannerAgent:
+    """Collect basic market data such as price, volume and volatility."""
+
+    data_source: str = "Yahoo Finance"
+
+    def analyze(self, symbol: str) -> Dict[str, Any]:
+        """Return market metrics for ``symbol``.
+
+        The method downloads roughly one month of daily data and reports the
+        latest values for price, volume, VWAP, 14-day ATR and realised
+        volatility.
+        """
+
+        df = yf.download(symbol, period="1mo", interval="1d", progress=False)
+        if df.empty:
+            raise ValueError(f"No data returned for symbol {symbol}")
+
+        close = df["Close"]
+        volume = df["Volume"]
+        high = df["High"]
+        low = df["Low"]
+
+        # VWAP using the typical price approximation.
+        typical = (high + low + close) / 3
+        vwap = float((typical * volume).sum() / volume.sum())
+
+        # Average True Range (ATR) over 14 periods
+        hl = high - low
+        hc = (high - close.shift()).abs()
+        lc = (low - close.shift()).abs()
+        tr = pd.concat([hl, hc, lc], axis=1).max(axis=1)
+        atr14 = float(tr.rolling(14).mean().iloc[-1])
+
+        # Realised volatility as standard deviation of log returns
+        returns = close.pct_change().dropna()
+        volatility = float(returns.std() * (len(returns) ** 0.5))
+
+        results = {
+            "price": float(close.iloc[-1]),
+            "volume": float(volume.iloc[-1]),
+            "vwap": vwap,
+            "atr_14": atr14,
+            "volatility": volatility,
+        }
+
+        return {
+            "agent": "MarketScannerAgent",
+            "symbol": symbol,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "metrics_used": list(results.keys()),
+            "results": results,
+            "summary": "Market metrics collected.",
+            "data_source": self.data_source,
+        }
+
+
+__all__: List[str] = ["MarketScannerAgent"]
+

--- a/trading_bot/agents/news_analyzer.py
+++ b/trading_bot/agents/news_analyzer.py
@@ -1,0 +1,57 @@
+"""News analysis agent.
+
+For this kata the agent works with a tiny built-in set of headlines per symbol
+and performs a naive sentiment calculation.  Real implementations would query a
+news API or RSS feed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+POSITIVE_WORDS = {"beat", "growth", "up", "surge", "gain"}
+NEGATIVE_WORDS = {"miss", "down", "fall", "loss", "drop"}
+
+
+@dataclass
+class NewsAnalyzerAgent:
+    """Analyse headline sentiment using a simple keyword approach."""
+
+    data_source: str = "sample"
+    headlines: Dict[str, List[str]] = field(
+        default_factory=lambda: {
+            "TSLA": [
+                "TSLA reports record delivery numbers",
+                "Analysts debate if TSLA rally can continue",
+            ]
+        }
+    )
+
+    def analyze(self, symbol: str) -> Dict[str, Any]:
+        headlines = self.headlines.get(symbol, [])
+        if not headlines:
+            sentiment = 0
+            summary = "No headlines"
+        else:
+            pos = sum(sum(w.lower() in POSITIVE_WORDS for w in h.split()) for h in headlines)
+            neg = sum(sum(w.lower() in NEGATIVE_WORDS for w in h.split()) for h in headlines)
+            sentiment = pos - neg
+            summary = "Positive" if sentiment > 0 else "Negative" if sentiment < 0 else "Neutral"
+
+        return {
+            "agent": "NewsAnalyzerAgent",
+            "symbol": symbol,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "methods_used": ["keyword_sentiment"],
+            "results": {"headlines": headlines, "sentiment": sentiment},
+            "summary": summary,
+            "sentiment": sentiment,
+            "data_source": self.data_source,
+        }
+
+
+__all__: List[str] = ["NewsAnalyzerAgent"]
+

--- a/trading_bot/agents/social_media.py
+++ b/trading_bot/agents/social_media.py
@@ -1,0 +1,59 @@
+"""Simple social media sentiment agent.
+
+The real project would connect to services such as StockTwits or Reddit to
+gauge retail sentiment.  For the purposes of this kata the agent operates on a
+very small, built-in sample dataset and performs rudimentary sentiment scoring
+based on positive/negative word counts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+POSITIVE_WORDS = {"buy", "bull", "long", "moon", "gain", "up"}
+NEGATIVE_WORDS = {"sell", "bear", "short", "down", "loss"}
+
+
+@dataclass
+class SocialMediaAgent:
+    """Analyse a very small sample of social media posts for sentiment."""
+
+    data_source: str = "sample"
+    samples: Dict[str, List[str]] = field(
+        default_factory=lambda: {
+            "TSLA": [
+                "TSLA to the moon!",
+                "Thinking of going long TSLA",
+                "TSLA might be overvalued",
+            ]
+        }
+    )
+
+    def analyze(self, symbol: str) -> Dict[str, Any]:
+        posts = self.samples.get(symbol, [])
+        if not posts:
+            summary = "No social data"
+            score = 0
+        else:
+            pos = sum(sum(w.lower() in POSITIVE_WORDS for w in p.split()) for p in posts)
+            neg = sum(sum(w.lower() in NEGATIVE_WORDS for w in p.split()) for p in posts)
+            score = pos - neg
+            summary = "Bullish" if score > 0 else "Bearish" if score < 0 else "Neutral"
+
+        return {
+            "agent": "SocialMediaAgent",
+            "symbol": symbol,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "methods_used": ["keyword_sentiment"],
+            "results": {"posts": posts, "score": score},
+            "summary": summary,
+            "score": score,
+            "data_source": self.data_source,
+        }
+
+
+__all__: List[str] = ["SocialMediaAgent"]
+

--- a/trading_bot/agents/technical_analysis.py
+++ b/trading_bot/agents/technical_analysis.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Technical analysis agent for computing basic indicators using yfinance.
+
+The agent fetches recent daily price data for a symbol from Yahoo Finance and
+computes a small selection of technical indicators.  Results are returned in a
+structured dictionary which mirrors the specification described in the project
+README.  This module is intentionally lightweight – it provides a minimal
+implementation that can be expanded upon by future contributors.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class TechnicalAnalysisAgent:
+    """Analyse a symbol using common technical indicators.
+
+    Parameters
+    ----------
+    indicators:
+        A list of indicator names that the agent should compute.  Supported
+        values are ``ema_9``, ``rsi_14`` and ``macd``.  If ``None`` is supplied
+        all indicators are calculated.
+    """
+
+    indicators: List[str] | None = None
+    data_source: str = "Yahoo Finance"
+
+    def analyze(self, symbol: str) -> Dict[str, Any]:
+        """Return indicator values for ``symbol``.
+
+        The method downloads roughly one month of daily data for ``symbol`` and
+        returns the last calculated value for each indicator.
+        """
+
+        indicators = self.indicators or ["ema_9", "rsi_14", "macd"]
+        df = yf.download(symbol, period="1mo", interval="1d", progress=False)
+
+        if df.empty:
+            raise ValueError(f"No data returned for symbol {symbol}")
+
+        results: Dict[str, float] = {}
+        closes = df["Close"]
+
+        if "ema_9" in indicators:
+            results["ema_9"] = float(closes.ewm(span=9).mean().iloc[-1])
+        if "rsi_14" in indicators:
+            delta = closes.diff()
+            up = delta.clip(lower=0).rolling(14).mean()
+            down = -delta.clip(upper=0).rolling(14).mean()
+            rs = up / down
+            rsi = 100 - 100 / (1 + rs)
+            results["rsi_14"] = float(rsi.iloc[-1])
+        if "macd" in indicators:
+            ema12 = closes.ewm(span=12).mean()
+            ema26 = closes.ewm(span=26).mean()
+            macd_line = ema12 - ema26
+            signal = macd_line.ewm(span=9).mean()
+            results["macd_hist"] = float(macd_line.iloc[-1] - signal.iloc[-1])
+
+        trend_signal = "bullish" if results.get("macd_hist", 0) > 0 else "bearish"
+
+        return {
+            "agent": "TechnicalAnalysisAgent",
+            "symbol": symbol,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "indicators_used": list(results.keys()),
+            "results": results,
+            "summary": f"Trend is {trend_signal} based on MACD histogram.",
+            "trend_signal": trend_signal,
+            "data_source": self.data_source,
+        }

--- a/trading_bot/backtest.py
+++ b/trading_bot/backtest.py
@@ -1,0 +1,73 @@
+"""Minimal backtesting utility.
+
+This is **not** a full featured backtesting engine but rather a lightweight
+implementation that mirrors the structure described in the project
+specification.  It performs a buy-and-hold simulation over the supplied date
+range using data retrieved from :mod:`yfinance`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class Backtester:
+    """Run a naive buy-and-hold simulation for a strategy."""
+
+    data_source: str = "Yahoo Finance"
+
+    def backtest(
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        strategy_dict: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        df = yf.download(
+            symbol,
+            start=start_date,
+            end=end_date,
+            interval="1d",
+            progress=False,
+        )
+        if df.empty:
+            raise ValueError("No data for backtest")
+
+        prices = df["Close"]
+        net_return = float(prices.iloc[-1] / prices.iloc[0] - 1)
+
+        roll_max = prices.cummax()
+        drawdown = (prices - roll_max) / roll_max
+        max_drawdown = float(drawdown.min())
+
+        trade_log = [
+            {
+                "entry_time": prices.index[0].isoformat(),
+                "entry_price": float(prices.iloc[0]),
+                "exit_time": prices.index[-1].isoformat(),
+                "exit_price": float(prices.iloc[-1]),
+                "pnl": float(prices.iloc[-1] - prices.iloc[0]),
+            }
+        ]
+
+        return {
+            "symbol": symbol,
+            "date_range": [start_date, end_date],
+            "net_return": net_return,
+            "max_drawdown": max_drawdown,
+            "trade_log": trade_log,
+            "equity_curve": [float(p) for p in prices],
+            "strategy_applied": strategy_dict,
+            "agent_inputs": {},
+            "data_source": self.data_source,
+        }
+
+
+__all__: List[str] = ["Backtester"]
+

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -1,0 +1,59 @@
+"""Strategy composer for combining agent outputs into an actionable plan."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, Optional
+
+
+def compose_strategy(
+    symbol: str,
+    *,
+    technical: Optional[Dict[str, Any]] = None,
+    market: Optional[Dict[str, Any]] = None,
+    news: Optional[Dict[str, Any]] = None,
+    social: Optional[Dict[str, Any]] = None,
+    macro: Optional[Dict[str, Any]] = None,
+    strategy_date: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a strategy dictionary from agent insights.
+
+    Parameters
+    ----------
+    symbol:
+        Ticker symbol to which the strategy applies.
+    technical, market, news, social, macro:
+        Dictionaries produced by the corresponding agents.
+    strategy_date:
+        ISO formatted date.  Defaults to today if ``None``.
+    """
+
+    strategy_date = strategy_date or date.today().isoformat()
+    technical = technical or {"summary": "", "details": {}}
+    market = market or {"summary": "", "details": {}}
+    news = news or {"summary": "", "headlines": []}
+    social = social or {"summary": "", "score": 0}
+    macro = macro or {"summary": ""}
+
+    entry_criteria = f"Enter long on {symbol} when technicals support bullish trend."
+    position_sizing = "Risk 2% of capital per trade."
+    risk_management = "Set stop-loss below recent swing low."
+    exit_strategy = "Take profit at 2R or when momentum fades."
+    trade_management = "Move stop to break-even after 1R gain."
+
+    return {
+        "symbol": symbol,
+        "date": strategy_date,
+        "entry_criteria": entry_criteria,
+        "position_sizing": position_sizing,
+        "risk_management": risk_management,
+        "exit_strategy": exit_strategy,
+        "trade_management": trade_management,
+        "rationale": {
+            "technical": {"summary": technical.get("summary", ""), "details": technical},
+            "market": market,
+            "news": news,
+            "social": social,
+            "macro": macro,
+        },
+    }


### PR DESCRIPTION
## Summary
- add `MarketScannerAgent` to compute price, volume, VWAP, ATR and volatility
- introduce `SocialMediaAgent` and `NewsAnalyzerAgent` with simple sentiment scoring
- implement minimal `Backtester` and extend strategy composer to include market rationale

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689175b1da648332a23ec2956fcfd5be