### PR TITLE
Expand trading agents with market, sentiment and news analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+
+data/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,37 @@
+# AI Trading Agent
 
+This repository contains the beginnings of an agent-based trading framework. It
+is intentionally lightweight and serves as a foundation for future work. The
+project structure includes:
+
+- **TechnicalAnalysisAgent** – downloads price data from Yahoo Finance and
+  computes a few common indicators (EMA, RSI and MACD).
+- **MarketScannerAgent** – collects price, volume, VWAP, ATR and volatility
+  metrics.
+- **SocialMediaAgent** – performs keyword based sentiment analysis on a small
+  sample of posts.
+- **NewsAnalyzerAgent** – analyses sample headlines for sentiment.
+- **Strategy Composer** – combines the outputs of agents into a single trading
+  strategy dictionary containing entry, sizing and risk guidelines.
+- **Backtester** – runs a minimal buy-and-hold simulation to evaluate a
+  composed strategy.
+- **JSON storage and portfolio tracking** – utility classes for persisting
+  strategies and tracking open/closed positions.
+- **Daily scheduler** – helper using APScheduler to trigger the pipeline for a
+  list of symbols at a configurable time.
+- **Pipeline** – convenience class that runs all agents, composes a strategy and
+  backtests it while optionally persisting outputs and updating a portfolio.
+
+The implementation is heavily simplified but follows the JSON schemas described
+in the project specification.
+
+## Running tests
+
+Install dependencies and execute the test-suite with `pytest`:
+
+```bash
+pip install -r requirements.txt
+pytest -q
+```
+
+Network access is not required for the tests as external data calls are mocked.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pandas
+yfinance
+apscheduler

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -1,0 +1,18 @@
+import pandas as pd
+from unittest.mock import patch
+
+from trading_bot.backtest import Backtester
+
+
+def test_backtester_returns_structure():
+    dates = pd.date_range("2024-01-01", periods=5)
+    df = pd.DataFrame({"Close": pd.Series([1, 2, 3, 4, 5], index=dates)})
+
+    with patch("yfinance.download", return_value=df):
+        bt = Backtester()
+        strategy = {"symbol": "TSLA"}
+        result = bt.backtest("TSLA", "2024-01-01", "2024-01-05", strategy)
+
+    assert result["symbol"] == "TSLA"
+    assert "net_return" in result and result["net_return"] > 0
+    assert result["trade_log"][0]["entry_price"] == 1

--- a/tests/test_market_scanner_agent.py
+++ b/tests/test_market_scanner_agent.py
@@ -1,0 +1,26 @@
+import pandas as pd
+from unittest.mock import patch
+
+from trading_bot.agents.market_scanner import MarketScannerAgent
+
+
+def test_market_scanner_returns_expected_structure():
+    dates = pd.date_range("2024-01-01", periods=30)
+    df = pd.DataFrame(
+        {
+            "Close": pd.Series(range(1, 31), index=dates),
+            "Volume": pd.Series(1000, index=dates),
+            "High": pd.Series(range(2, 32), index=dates),
+            "Low": pd.Series(range(0, 30), index=dates),
+        }
+    )
+
+    with patch("yfinance.download", return_value=df):
+        agent = MarketScannerAgent()
+        result = agent.analyze("TSLA")
+
+    assert result["agent"] == "MarketScannerAgent"
+    assert result["symbol"] == "TSLA"
+    assert {"price", "volume", "vwap", "atr_14", "volatility"} <= set(
+        result["results"].keys()
+    )

--- a/tests/test_social_news_agents.py
+++ b/tests/test_social_news_agents.py
@@ -1,0 +1,16 @@
+from trading_bot.agents.social_media import SocialMediaAgent
+from trading_bot.agents.news_analyzer import NewsAnalyzerAgent
+
+
+def test_social_media_agent_structure():
+    agent = SocialMediaAgent()
+    result = agent.analyze("TSLA")
+    assert result["agent"] == "SocialMediaAgent"
+    assert "score" in result
+
+
+def test_news_analyzer_agent_structure():
+    agent = NewsAnalyzerAgent()
+    result = agent.analyze("TSLA")
+    assert result["agent"] == "NewsAnalyzerAgent"
+    assert "sentiment" in result

--- a/tests/test_storage_portfolio_scheduler.py
+++ b/tests/test_storage_portfolio_scheduler.py
@@ -1,0 +1,41 @@
+import os
+from datetime import datetime
+
+from trading_bot.storage import JSONStorage
+from trading_bot.portfolio import Portfolio
+from trading_bot.scheduler import schedule_daily_run
+
+
+def test_json_storage_roundtrip(tmp_path):
+    storage = JSONStorage(base_dir=tmp_path)
+    data = {"foo": 1}
+    path = storage.save("strategy", "TSLA", "2024-01-01", data)
+    assert path.exists()
+    loaded = storage.load("strategy", "TSLA", "2024-01-01")
+    assert loaded == data
+
+
+def test_portfolio_tracks_positions():
+    pf = Portfolio()
+    pos = pf.open_position(
+        "TSLA", 10, 100.0, datetime(2024, 1, 1, 9, 30), "strat1"
+    )
+    assert pf.open_positions() == [pos]
+    pf.close_position(pos, 110.0, datetime(2024, 1, 2, 10, 0))
+    assert pf.closed_positions() == [pos]
+    assert pos.pnl() == 100.0
+
+
+def test_scheduler_creates_jobs():
+    calls = []
+
+    def job(symbol):
+        calls.append(symbol)
+
+    scheduler = schedule_daily_run(job, ["TSLA", "AAPL"], run_time="00:00", timezone="UTC")
+    try:
+        jobs = scheduler.get_jobs()
+        assert len(jobs) == 2
+        assert {job.id for job in jobs} == {"TSLA", "AAPL"}
+    finally:
+        scheduler.shutdown()

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,29 @@
+from trading_bot.strategy import compose_strategy
+
+
+def test_compose_strategy_structure():
+    technical = {"summary": "Bullish"}
+    market = {"summary": ""}
+    news = {"summary": "", "headlines": []}
+    social = {"summary": "", "score": 0}
+    macro = {"summary": ""}
+    strategy = compose_strategy(
+        symbol="TSLA",
+        technical=technical,
+        market=market,
+        news=news,
+        social=social,
+        macro=macro,
+        strategy_date="2024-01-01",
+    )
+
+    assert strategy["symbol"] == "TSLA"
+    for key in [
+        "entry_criteria",
+        "position_sizing",
+        "risk_management",
+        "exit_strategy",
+        "trade_management",
+    ]:
+        assert key in strategy
+    assert "rationale" in strategy and "market" in strategy["rationale"]

--- a/tests/test_technical_analysis_agent.py
+++ b/tests/test_technical_analysis_agent.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from unittest.mock import patch
+
+from trading_bot.agents.technical_analysis import TechnicalAnalysisAgent
+
+
+def test_analyze_returns_expected_structure():
+    # Create deterministic price series so indicator values are stable
+    close = pd.Series(range(1, 31), index=pd.date_range("2024-01-01", periods=30))
+    df = pd.DataFrame({"Close": close})
+
+    with patch("yfinance.download", return_value=df):
+        agent = TechnicalAnalysisAgent()
+        result = agent.analyze("TSLA")
+
+    assert result["agent"] == "TechnicalAnalysisAgent"
+    assert result["symbol"] == "TSLA"
+    assert set(result["indicators_used"]) == {"ema_9", "rsi_14", "macd_hist"}
+    assert {"ema_9", "rsi_14", "macd_hist"} <= result["results"].keys()
+    assert result["trend_signal"] in {"bullish", "bearish"}

--- a/trading_bot/agents/__init__.py
+++ b/trading_bot/agents/__init__.py
@@ -1,0 +1,14 @@
+"""Agents package exposes available agent classes."""
+
+from .technical_analysis import TechnicalAnalysisAgent
+from .market_scanner import MarketScannerAgent
+from .social_media import SocialMediaAgent
+from .news_analyzer import NewsAnalyzerAgent
+
+__all__ = [
+    "TechnicalAnalysisAgent",
+    "MarketScannerAgent",
+    "SocialMediaAgent",
+    "NewsAnalyzerAgent",
+]
+

--- a/trading_bot/agents/market_scanner.py
+++ b/trading_bot/agents/market_scanner.py
@@ -1,0 +1,78 @@
+"""Market scanner agent for basic market metrics.
+
+This agent fetches recent price data via :mod:`yfinance` and extracts a
+handful of metrics that are typically used to gauge the current market
+environment for a given symbol.  The implementation is intentionally
+lightweight but follows the structured output format described in the project
+specification.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class MarketScannerAgent:
+    """Collect basic market data such as price, volume and volatility."""
+
+    data_source: str = "Yahoo Finance"
+
+    def analyze(self, symbol: str) -> Dict[str, Any]:
+        """Return market metrics for ``symbol``.
+
+        The method downloads roughly one month of daily data and reports the
+        latest values for price, volume, VWAP, 14-day ATR and realised
+        volatility.
+        """
+
+        df = yf.download(symbol, period="1mo", interval="1d", progress=False)
+        if df.empty:
+            raise ValueError(f"No data returned for symbol {symbol}")
+
+        close = df["Close"]
+        volume = df["Volume"]
+        high = df["High"]
+        low = df["Low"]
+
+        # VWAP using the typical price approximation.
+        typical = (high + low + close) / 3
+        vwap = float((typical * volume).sum() / volume.sum())
+
+        # Average True Range (ATR) over 14 periods
+        hl = high - low
+        hc = (high - close.shift()).abs()
+        lc = (low - close.shift()).abs()
+        tr = pd.concat([hl, hc, lc], axis=1).max(axis=1)
+        atr14 = float(tr.rolling(14).mean().iloc[-1])
+
+        # Realised volatility as standard deviation of log returns
+        returns = close.pct_change().dropna()
+        volatility = float(returns.std() * (len(returns) ** 0.5))
+
+        results = {
+            "price": float(close.iloc[-1]),
+            "volume": float(volume.iloc[-1]),
+            "vwap": vwap,
+            "atr_14": atr14,
+            "volatility": volatility,
+        }
+
+        return {
+            "agent": "MarketScannerAgent",
+            "symbol": symbol,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "metrics_used": list(results.keys()),
+            "results": results,
+            "summary": "Market metrics collected.",
+            "data_source": self.data_source,
+        }
+
+
+__all__: List[str] = ["MarketScannerAgent"]
+

--- a/trading_bot/agents/news_analyzer.py
+++ b/trading_bot/agents/news_analyzer.py
@@ -1,0 +1,57 @@
+"""News analysis agent.
+
+For this kata the agent works with a tiny built-in set of headlines per symbol
+and performs a naive sentiment calculation.  Real implementations would query a
+news API or RSS feed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+POSITIVE_WORDS = {"beat", "growth", "up", "surge", "gain"}
+NEGATIVE_WORDS = {"miss", "down", "fall", "loss", "drop"}
+
+
+@dataclass
+class NewsAnalyzerAgent:
+    """Analyse headline sentiment using a simple keyword approach."""
+
+    data_source: str = "sample"
+    headlines: Dict[str, List[str]] = field(
+        default_factory=lambda: {
+            "TSLA": [
+                "TSLA reports record delivery numbers",
+                "Analysts debate if TSLA rally can continue",
+            ]
+        }
+    )
+
+    def analyze(self, symbol: str) -> Dict[str, Any]:
+        headlines = self.headlines.get(symbol, [])
+        if not headlines:
+            sentiment = 0
+            summary = "No headlines"
+        else:
+            pos = sum(sum(w.lower() in POSITIVE_WORDS for w in h.split()) for h in headlines)
+            neg = sum(sum(w.lower() in NEGATIVE_WORDS for w in h.split()) for h in headlines)
+            sentiment = pos - neg
+            summary = "Positive" if sentiment > 0 else "Negative" if sentiment < 0 else "Neutral"
+
+        return {
+            "agent": "NewsAnalyzerAgent",
+            "symbol": symbol,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "methods_used": ["keyword_sentiment"],
+            "results": {"headlines": headlines, "sentiment": sentiment},
+            "summary": summary,
+            "sentiment": sentiment,
+            "data_source": self.data_source,
+        }
+
+
+__all__: List[str] = ["NewsAnalyzerAgent"]
+

--- a/trading_bot/agents/social_media.py
+++ b/trading_bot/agents/social_media.py
@@ -1,0 +1,59 @@
+"""Simple social media sentiment agent.
+
+The real project would connect to services such as StockTwits or Reddit to
+gauge retail sentiment.  For the purposes of this kata the agent operates on a
+very small, built-in sample dataset and performs rudimentary sentiment scoring
+based on positive/negative word counts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+
+POSITIVE_WORDS = {"buy", "bull", "long", "moon", "gain", "up"}
+NEGATIVE_WORDS = {"sell", "bear", "short", "down", "loss"}
+
+
+@dataclass
+class SocialMediaAgent:
+    """Analyse a very small sample of social media posts for sentiment."""
+
+    data_source: str = "sample"
+    samples: Dict[str, List[str]] = field(
+        default_factory=lambda: {
+            "TSLA": [
+                "TSLA to the moon!",
+                "Thinking of going long TSLA",
+                "TSLA might be overvalued",
+            ]
+        }
+    )
+
+    def analyze(self, symbol: str) -> Dict[str, Any]:
+        posts = self.samples.get(symbol, [])
+        if not posts:
+            summary = "No social data"
+            score = 0
+        else:
+            pos = sum(sum(w.lower() in POSITIVE_WORDS for w in p.split()) for p in posts)
+            neg = sum(sum(w.lower() in NEGATIVE_WORDS for w in p.split()) for p in posts)
+            score = pos - neg
+            summary = "Bullish" if score > 0 else "Bearish" if score < 0 else "Neutral"
+
+        return {
+            "agent": "SocialMediaAgent",
+            "symbol": symbol,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "methods_used": ["keyword_sentiment"],
+            "results": {"posts": posts, "score": score},
+            "summary": summary,
+            "score": score,
+            "data_source": self.data_source,
+        }
+
+
+__all__: List[str] = ["SocialMediaAgent"]
+

--- a/trading_bot/agents/technical_analysis.py
+++ b/trading_bot/agents/technical_analysis.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+"""Technical analysis agent for computing basic indicators using yfinance.
+
+The agent fetches recent daily price data for a symbol from Yahoo Finance and
+computes a small selection of technical indicators.  Results are returned in a
+structured dictionary which mirrors the specification described in the project
+README.  This module is intentionally lightweight – it provides a minimal
+implementation that can be expanded upon by future contributors.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class TechnicalAnalysisAgent:
+    """Analyse a symbol using common technical indicators.
+
+    Parameters
+    ----------
+    indicators:
+        A list of indicator names that the agent should compute.  Supported
+        values are ``ema_9``, ``rsi_14`` and ``macd``.  If ``None`` is supplied
+        all indicators are calculated.
+    """
+
+    indicators: List[str] | None = None
+    data_source: str = "Yahoo Finance"
+
+    def analyze(self, symbol: str) -> Dict[str, Any]:
+        """Return indicator values for ``symbol``.
+
+        The method downloads roughly one month of daily data for ``symbol`` and
+        returns the last calculated value for each indicator.
+        """
+
+        indicators = self.indicators or ["ema_9", "rsi_14", "macd"]
+        df = yf.download(symbol, period="1mo", interval="1d", progress=False)
+
+        if df.empty:
+            raise ValueError(f"No data returned for symbol {symbol}")
+
+        results: Dict[str, float] = {}
+        closes = df["Close"]
+
+        if "ema_9" in indicators:
+            results["ema_9"] = float(closes.ewm(span=9).mean().iloc[-1])
+        if "rsi_14" in indicators:
+            delta = closes.diff()
+            up = delta.clip(lower=0).rolling(14).mean()
+            down = -delta.clip(upper=0).rolling(14).mean()
+            rs = up / down
+            rsi = 100 - 100 / (1 + rs)
+            results["rsi_14"] = float(rsi.iloc[-1])
+        if "macd" in indicators:
+            ema12 = closes.ewm(span=12).mean()
+            ema26 = closes.ewm(span=26).mean()
+            macd_line = ema12 - ema26
+            signal = macd_line.ewm(span=9).mean()
+            results["macd_hist"] = float(macd_line.iloc[-1] - signal.iloc[-1])
+
+        trend_signal = "bullish" if results.get("macd_hist", 0) > 0 else "bearish"
+
+        return {
+            "agent": "TechnicalAnalysisAgent",
+            "symbol": symbol,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "indicators_used": list(results.keys()),
+            "results": results,
+            "summary": f"Trend is {trend_signal} based on MACD histogram.",
+            "trend_signal": trend_signal,
+            "data_source": self.data_source,
+        }

--- a/trading_bot/backtest.py
+++ b/trading_bot/backtest.py
@@ -1,0 +1,73 @@
+"""Minimal backtesting utility.
+
+This is **not** a full featured backtesting engine but rather a lightweight
+implementation that mirrors the structure described in the project
+specification.  It performs a buy-and-hold simulation over the supplied date
+range using data retrieved from :mod:`yfinance`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List
+
+import pandas as pd
+import yfinance as yf
+
+
+@dataclass
+class Backtester:
+    """Run a naive buy-and-hold simulation for a strategy."""
+
+    data_source: str = "Yahoo Finance"
+
+    def backtest(
+        self,
+        symbol: str,
+        start_date: str,
+        end_date: str,
+        strategy_dict: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        df = yf.download(
+            symbol,
+            start=start_date,
+            end=end_date,
+            interval="1d",
+            progress=False,
+        )
+        if df.empty:
+            raise ValueError("No data for backtest")
+
+        prices = df["Close"]
+        net_return = float(prices.iloc[-1] / prices.iloc[0] - 1)
+
+        roll_max = prices.cummax()
+        drawdown = (prices - roll_max) / roll_max
+        max_drawdown = float(drawdown.min())
+
+        trade_log = [
+            {
+                "entry_time": prices.index[0].isoformat(),
+                "entry_price": float(prices.iloc[0]),
+                "exit_time": prices.index[-1].isoformat(),
+                "exit_price": float(prices.iloc[-1]),
+                "pnl": float(prices.iloc[-1] - prices.iloc[0]),
+            }
+        ]
+
+        return {
+            "symbol": symbol,
+            "date_range": [start_date, end_date],
+            "net_return": net_return,
+            "max_drawdown": max_drawdown,
+            "trade_log": trade_log,
+            "equity_curve": [float(p) for p in prices],
+            "strategy_applied": strategy_dict,
+            "agent_inputs": {},
+            "data_source": self.data_source,
+        }
+
+
+__all__: List[str] = ["Backtester"]
+

--- a/trading_bot/pipeline.py
+++ b/trading_bot/pipeline.py
@@ -1,0 +1,102 @@
+"""High level pipeline for running the trading workflow for one symbol.
+
+This module ties together the various agents, strategy composer, backtester
+and storage utilities to execute the full daily routine described in the
+project specification.  The implementation is intentionally minimal but shows
+how the pieces fit together and provides a convenient function for unit tests
+or scripts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Any, Optional
+
+from .agents import (
+    TechnicalAnalysisAgent,
+    MarketScannerAgent,
+    SocialMediaAgent,
+    NewsAnalyzerAgent,
+)
+from .strategy import compose_strategy
+from .backtest import Backtester
+from .storage import JSONStorage
+from .portfolio import Portfolio
+
+
+@dataclass
+class Pipeline:
+    """Run all agents, compose a strategy and backtest it."""
+
+    storage: Optional[JSONStorage] = None
+    portfolio: Optional[Portfolio] = None
+    backtester: Backtester = Backtester()
+
+    def run(self, symbol: str, start_date: str, end_date: str) -> Dict[str, Any]:
+        """Execute the full pipeline for ``symbol``.
+
+        Parameters
+        ----------
+        symbol:
+            Ticker symbol to analyse.
+        start_date, end_date:
+            Date range for the backtest in ``YYYY-MM-DD`` format.
+        """
+
+        # Run agents ------------------------------------------------------
+        technical = TechnicalAnalysisAgent().analyze(symbol)
+        market = MarketScannerAgent().analyze(symbol)
+        social = SocialMediaAgent().analyze(symbol)
+        news = NewsAnalyzerAgent().analyze(symbol)
+
+        # Compose strategy -------------------------------------------------
+        strategy = compose_strategy(
+            symbol,
+            technical=technical,
+            market=market,
+            news=news,
+            social=social,
+        )
+
+        # Backtest ---------------------------------------------------------
+        bt_result = self.backtester.backtest(symbol, start_date, end_date, strategy)
+
+        # Persist outputs --------------------------------------------------
+        date_str = start_date
+        if self.storage:
+            self.storage.save("technical", symbol, date_str, technical)
+            self.storage.save("market", symbol, date_str, market)
+            self.storage.save("social", symbol, date_str, social)
+            self.storage.save("news", symbol, date_str, news)
+            self.storage.save("strategy", symbol, date_str, strategy)
+            self.storage.save("backtest", symbol, date_str, bt_result)
+
+        # Update portfolio -------------------------------------------------
+        if self.portfolio:
+            trade = bt_result["trade_log"][0]
+            pos = self.portfolio.open_position(
+                symbol,
+                size=1,
+                entry_price=trade["entry_price"],
+                entry_time=datetime.fromisoformat(trade["entry_time"]),
+                strategy_ref=date_str,
+            )
+            self.portfolio.close_position(
+                pos,
+                exit_price=trade["exit_price"],
+                exit_time=datetime.fromisoformat(trade["exit_time"]),
+            )
+
+        return {
+            "symbol": symbol,
+            "technical": technical,
+            "market": market,
+            "social": social,
+            "news": news,
+            "strategy": strategy,
+            "backtest": bt_result,
+        }
+
+
+__all__ = ["Pipeline"]

--- a/trading_bot/portfolio.py
+++ b/trading_bot/portfolio.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Very small portfolio tracking utility.
+
+The :class:`Portfolio` class stores opened and closed positions allowing the
+system to track PnL over time.  It is deliberately lightweight but mirrors the
+fields described in the project specification.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+
+
+@dataclass
+class Position:
+    symbol: str
+    size: float
+    entry_price: float
+    entry_time: datetime
+    strategy_ref: str
+    exit_price: Optional[float] = None
+    exit_time: Optional[datetime] = None
+
+    def is_open(self) -> bool:  # pragma: no cover - trivial
+        return self.exit_price is None
+
+    def pnl(self) -> Optional[float]:
+        if self.exit_price is None:
+            return None
+        return (self.exit_price - self.entry_price) * self.size
+
+
+class Portfolio:
+    """Track open and closed positions."""
+
+    def __init__(self) -> None:
+        self.positions: List[Position] = []
+
+    # Opening and closing -------------------------------------------------
+    def open_position(
+        self,
+        symbol: str,
+        size: float,
+        entry_price: float,
+        entry_time: datetime,
+        strategy_ref: str,
+    ) -> Position:
+        pos = Position(symbol, size, entry_price, entry_time, strategy_ref)
+        self.positions.append(pos)
+        return pos
+
+    def close_position(self, position: Position, exit_price: float, exit_time: datetime) -> Position:
+        position.exit_price = exit_price
+        position.exit_time = exit_time
+        return position
+
+    # Query helpers -------------------------------------------------------
+    def open_positions(self) -> List[Position]:
+        return [p for p in self.positions if p.is_open()]
+
+    def closed_positions(self) -> List[Position]:
+        return [p for p in self.positions if not p.is_open()]
+
+
+__all__ = ["Portfolio", "Position"]

--- a/trading_bot/scheduler.py
+++ b/trading_bot/scheduler.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+"""Daily scheduler for running the trading pipeline.
+
+The function :func:`schedule_daily_run` creates an APScheduler background
+scheduler that will execute ``job_func`` once per day for each symbol at the
+specified time (default ``08:00`` Eastern).  The caller is responsible for
+shutting the scheduler down when the application exits.
+"""
+
+from typing import Callable, Iterable
+from apscheduler.schedulers.background import BackgroundScheduler
+
+
+def schedule_daily_run(
+    job_func: Callable[[str], None],
+    symbols: Iterable[str],
+    run_time: str = "08:00",
+    timezone: str = "US/Eastern",
+) -> BackgroundScheduler:
+    """Schedule ``job_func`` for each symbol once per day."""
+
+    hour, minute = (int(part) for part in run_time.split(":", 1))
+    scheduler = BackgroundScheduler(timezone=timezone)
+    for symbol in symbols:
+        scheduler.add_job(
+            job_func,
+            "cron",
+            args=[symbol],
+            id=symbol,
+            hour=hour,
+            minute=minute,
+        )
+    scheduler.start()
+    return scheduler
+
+
+__all__ = ["schedule_daily_run"]

--- a/trading_bot/storage.py
+++ b/trading_bot/storage.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+"""Simple JSON storage helpers for persisting bot outputs.
+
+The real project might use a database, but for unit tests and lightweight
+usage we write each record to a ``data/`` directory organised by symbol.  This
+module provides minimal ``save`` and ``load`` helpers.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict
+import json
+
+
+@dataclass
+class JSONStorage:
+    """Persist dictionaries as JSON files on disk."""
+
+    base_dir: Path | str = Path("data")
+
+    def __post_init__(self) -> None:
+        self.base_dir = Path(self.base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, category: str, symbol: str, date_str: str) -> Path:
+        symbol_dir = self.base_dir / symbol
+        symbol_dir.mkdir(parents=True, exist_ok=True)
+        return symbol_dir / f"{date_str}_{category}.json"
+
+    def save(self, category: str, symbol: str, date_str: str, data: Dict[str, Any]) -> Path:
+        """Write ``data`` to disk and return the file path."""
+        path = self._path(category, symbol, date_str)
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(data, fh, indent=2)
+        return path
+
+    def load(self, category: str, symbol: str, date_str: str) -> Dict[str, Any]:
+        """Load and return data previously saved with :meth:`save`."""
+        path = self._path(category, symbol, date_str)
+        with path.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+
+
+__all__ = ["JSONStorage"]

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -1,0 +1,59 @@
+"""Strategy composer for combining agent outputs into an actionable plan."""
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, Dict, Optional
+
+
+def compose_strategy(
+    symbol: str,
+    *,
+    technical: Optional[Dict[str, Any]] = None,
+    market: Optional[Dict[str, Any]] = None,
+    news: Optional[Dict[str, Any]] = None,
+    social: Optional[Dict[str, Any]] = None,
+    macro: Optional[Dict[str, Any]] = None,
+    strategy_date: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a strategy dictionary from agent insights.
+
+    Parameters
+    ----------
+    symbol:
+        Ticker symbol to which the strategy applies.
+    technical, market, news, social, macro:
+        Dictionaries produced by the corresponding agents.
+    strategy_date:
+        ISO formatted date.  Defaults to today if ``None``.
+    """
+
+    strategy_date = strategy_date or date.today().isoformat()
+    technical = technical or {"summary": "", "details": {}}
+    market = market or {"summary": "", "details": {}}
+    news = news or {"summary": "", "headlines": []}
+    social = social or {"summary": "", "score": 0}
+    macro = macro or {"summary": ""}
+
+    entry_criteria = f"Enter long on {symbol} when technicals support bullish trend."
+    position_sizing = "Risk 2% of capital per trade."
+    risk_management = "Set stop-loss below recent swing low."
+    exit_strategy = "Take profit at 2R or when momentum fades."
+    trade_management = "Move stop to break-even after 1R gain."
+
+    return {
+        "symbol": symbol,
+        "date": strategy_date,
+        "entry_criteria": entry_criteria,
+        "position_sizing": position_sizing,
+        "risk_management": risk_management,
+        "exit_strategy": exit_strategy,
+        "trade_management": trade_management,
+        "rationale": {
+            "technical": {"summary": technical.get("summary", ""), "details": technical},
+            "market": market,
+            "news": news,
+            "social": social,
+            "macro": macro,
+        },
+    }


### PR DESCRIPTION
## Summary
- introduce JSONStorage for persisting agent outputs and composed strategies
- add Portfolio class for tracking open and closed positions with PnL
- provide schedule_daily_run helper to trigger the pipeline at a configured time
- add Pipeline orchestrator that runs all agents, backtests strategies and logs results

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689175b1da648332a23ec2956fcfd5be