### PR TITLE
Handle optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ For each configured symbol the pipeline performs:
 ## Step‑by‑Step Usage
 
 1. **Install dependencies and run tests**
+
+   This project requires the `yfinance` and `apscheduler` packages for data
+   retrieval and scheduling. They are included in `requirements.txt`.
+
    ```bash
    pip install -r requirements.txt
    pytest -q

--- a/trading_bot/agents/technical_analysis.py
+++ b/trading_bot/agents/technical_analysis.py
@@ -14,7 +14,6 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 import pandas as pd
-import yfinance as yf
 
 
 @dataclass
@@ -38,6 +37,12 @@ class TechnicalAnalysisAgent:
         The method downloads roughly one month of daily data for ``symbol`` and
         returns the last calculated value for each indicator.
         """
+        try:
+            import yfinance as yf  # type: ignore
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "yfinance is required for TechnicalAnalysisAgent. Install it with 'pip install yfinance'."
+            ) from exc
 
         indicators = self.indicators or ["ema_9", "rsi_14", "macd"]
         df = yf.download(symbol, period="1mo", interval="1d", progress=False)

--- a/trading_bot/backtest.py
+++ b/trading_bot/backtest.py
@@ -13,7 +13,6 @@ from datetime import datetime
 from typing import Any, Dict, List
 
 import pandas as pd
-import yfinance as yf
 
 
 @dataclass
@@ -29,6 +28,13 @@ class Backtester:
         end_date: str,
         strategy_dict: Dict[str, Any],
     ) -> Dict[str, Any]:
+        try:
+            import yfinance as yf  # type: ignore
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "yfinance is required for backtesting. Install it with 'pip install yfinance'."
+            ) from exc
+
         df = yf.download(
             symbol,
             start=start_date,

--- a/trading_bot/scheduler.py
+++ b/trading_bot/scheduler.py
@@ -9,7 +9,6 @@ shutting the scheduler down when the application exits.
 """
 
 from typing import Callable, Iterable
-from apscheduler.schedulers.background import BackgroundScheduler
 
 
 def schedule_daily_run(
@@ -19,6 +18,13 @@ def schedule_daily_run(
     timezone: str = "US/Eastern",
 ) -> BackgroundScheduler:
     """Schedule ``job_func`` for each symbol once per day."""
+
+    try:
+        from apscheduler.schedulers.background import BackgroundScheduler  # type: ignore
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "apscheduler is required to schedule daily runs. Install it with 'pip install apscheduler'."
+        ) from exc
 
     hour, minute = (int(part) for part in run_time.split(":", 1))
     scheduler = BackgroundScheduler(timezone=timezone)


### PR DESCRIPTION
## Summary
- handle missing `yfinance` by lazily importing with a helpful error in technical analysis agent and backtester
- defer `apscheduler` import until scheduling and raise install instruction if absent
- document required packages `yfinance` and `apscheduler` in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689186c9eff08332ac4713903bcabb52