### PR TITLE
Add LLM-based agent for symbol analysis

### DIFF
--- a/trading_bot/agents/__init__.py
+++ b/trading_bot/agents/__init__.py
@@ -4,11 +4,13 @@ from .technical_analysis import TechnicalAnalysisAgent
 from .market_scanner import MarketScannerAgent
 from .social_media import SocialMediaAgent
 from .news_analyzer import NewsAnalyzerAgent
+from .llm_agent import LLMAgent
 
 __all__ = [
     "TechnicalAnalysisAgent",
     "MarketScannerAgent",
     "SocialMediaAgent",
     "NewsAnalyzerAgent",
+    "LLMAgent",
 ]
 

--- a/trading_bot/agents/llm_agent.py
+++ b/trading_bot/agents/llm_agent.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+"""Lightweight agent that queries an LLM for market commentary.
+
+The agent relies on :mod:`trading_bot.llm_client` to interact with OpenAI's
+API.  The text response from the model is wrapped into a small structured
+dictionary so it fits the common interface used across the project.
+"""
+
+from typing import Dict
+
+
+class LLMAgent:
+    """Generate a brief analysis for a ticker symbol using a language model."""
+
+    def analyze(self, symbol: str) -> Dict[str, str]:
+        """Return an LLM-generated summary for ``symbol``.
+
+        The method crafts a prompt referencing ``symbol`` and delegates the
+        request to :func:`trading_bot.llm_client.call_openai`.  The raw text
+        reply from the model is packaged into a simple dictionary alongside a
+        one-line summary extracted from the response.
+        """
+
+        try:  # Import lazily so missing dependencies don't break module import.
+            from trading_bot import llm_client
+        except Exception as exc:  # pragma: no cover - exercised when dependency missing
+            raise ImportError(
+                "llm_client (and openai) must be available to use LLMAgent"
+            ) from exc
+
+        prompt = f"Provide a concise investment summary for the stock symbol {symbol}."
+        raw_response = llm_client.call_openai(prompt)
+        summary = raw_response.strip().splitlines()[0] if raw_response else ""
+
+        return {
+            "agent": "LLMAgent",
+            "symbol": symbol,
+            "summary": summary,
+            "raw_response": raw_response,
+        }
+
+
+__all__ = ["LLMAgent"]


### PR DESCRIPTION
## Summary
- add `LLMAgent` to query OpenAI via llm_client and return structured summary
- expose `LLMAgent` in agents package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_689195f201f08332ab5e60f6bdbf61ea