### PR TITLE
Add trading pipeline demo notebook

### DIFF
--- a/notebooks/trading_pipeline_demo.ipynb
+++ b/notebooks/trading_pipeline_demo.ipynb
@@ -1,0 +1,45 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from trading_bot.agents import (\n",
+    "    TechnicalAnalysisAgent, MarketScannerAgent,\n",
+    "    SocialMediaAgent, NewsAnalyzerAgent,\n",
+    ")\n",
+    "from trading_bot.pipeline import Pipeline\n",
+    "from trading_bot.storage import JSONStorage\n",
+    "from trading_bot.portfolio import Portfolio\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agents = [TechnicalAnalysisAgent(), MarketScannerAgent(),\n",
+    "          SocialMediaAgent(), NewsAnalyzerAgent()]\n",
+    "pipeline = Pipeline(agents, storage=JSONStorage(\"data\"),\n",
+    "                    portfolio=Portfolio())\n",
+    "result = pipeline.run_for_symbol(\"TSLA\")\n",
+    "result[\"strategy\"]\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/trading_pipeline_demo.ipynb
+++ b/notebooks/trading_pipeline_demo.ipynb
@@ -1,8 +1,19 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "87a6addf",
+   "metadata": {},
+   "source": [
+    "# Trading Pipeline Demo\n",
+    "\n",
+    "This notebook demonstrates how to run the trading pipeline with multiple agents to generate a strategy for a given ticker."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
+   "id": "23215d35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -18,6 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "e2a79977",
    "metadata": {},
    "outputs": [],
    "source": [


### PR DESCRIPTION
## Summary
- add `trading_pipeline_demo.ipynb` showing how to run a basic trading pipeline with multiple agents

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6892288f68648332b667d4e42d8a0097