### PR TITLE
Add OpenAI client wrapper and tests

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,30 @@
+from unittest.mock import MagicMock, patch
+import os
+import types
+
+import pytest
+from openai import OpenAIError
+
+from trading_bot import openai_client
+
+
+def test_call_openai_success():
+    fake_response = types.SimpleNamespace(
+        choices=[types.SimpleNamespace(message={"content": "hello world"})]
+    )
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
+        with patch("openai.ChatCompletion.create", return_value=fake_response) as mock_create:
+            result = openai_client.call_openai("hi", temperature=0.2)
+    assert result == "hello world"
+    mock_create.assert_called_once_with(
+        model="gpt-3.5-turbo",
+        messages=[{"role": "user", "content": "hi"}],
+        temperature=0.2,
+    )
+
+
+def test_call_openai_raises_runtime_error_on_openaierror():
+    with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
+        with patch("openai.ChatCompletion.create", side_effect=OpenAIError("boom")):
+            with pytest.raises(RuntimeError):
+                openai_client.call_openai("hi")

--- a/trading_bot/openai_client.py
+++ b/trading_bot/openai_client.py
@@ -1,0 +1,55 @@
+"""Lightweight wrapper around OpenAI's ChatCompletion API."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import openai
+try:  # pragma: no cover - import path differs between OpenAI versions
+    from openai.error import OpenAIError
+except Exception:  # pragma: no cover
+    from openai import OpenAIError
+
+
+def call_openai(prompt: str, *, temperature: float = 0.7) -> str:
+    """Send ``prompt`` to OpenAI and return the model's reply.
+
+    Parameters
+    ----------
+    prompt:
+        Text prompt to send to the model.
+    temperature:
+        Sampling temperature to use for the completion.
+
+    Returns
+    -------
+    str
+        The text of the model's response.
+
+    Raises
+    ------
+    ValueError
+        If ``OPENAI_API_KEY`` is not set in the environment.
+    RuntimeError
+        If the OpenAI API returns an error.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY environment variable is not set")
+
+    openai.api_key = api_key
+
+    try:
+        response: Any = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[{"role": "user", "content": prompt}],
+            temperature=temperature,
+        )
+    except OpenAIError as exc:
+        raise RuntimeError(f"OpenAI API error: {exc}") from exc
+
+    return response.choices[0].message["content"].strip()
+
+
+__all__ = ["call_openai"]


### PR DESCRIPTION
## Summary
- add `call_openai` wrapper with temperature and error handling
- test OpenAI client using mocks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68923296c8c483328b426c30a9ca46eb