### PR TITLE
Add role-based LLM agents and tests

### DIFF
--- a/tests/test_llm_roles.py
+++ b/tests/test_llm_roles.py
@@ -1,0 +1,49 @@
+from unittest.mock import MagicMock, patch
+
+from trading_bot.agents import (
+    MarketAnalystAgent,
+    NewsSummarizerAgent,
+    RiskAdvisorAgent,
+)
+
+
+def test_market_analyst_agent_uses_prompt_template():
+    response_text = "Analysis result"
+    fake_call = MagicMock(return_value=response_text)
+    with patch("trading_bot.openai_client.call_openai", fake_call):
+        template = "Analyze the market for {symbol}"
+        agent = MarketAnalystAgent(prompt_template=template)
+        result = agent.analyze("AAPL")
+        fake_call.assert_called_once_with("Analyze the market for AAPL")
+
+    assert result["agent"] == "MarketAnalystAgent"
+    assert result["symbol"] == "AAPL"
+    assert result["analysis"] == response_text
+
+
+def test_risk_advisor_agent_uses_prompt_template():
+    response_text = "Risk assessment"
+    fake_call = MagicMock(return_value=response_text)
+    with patch("trading_bot.openai_client.call_openai", fake_call):
+        template = "Assess risks for {symbol}"
+        agent = RiskAdvisorAgent(prompt_template=template)
+        result = agent.assess("TSLA")
+        fake_call.assert_called_once_with("Assess risks for TSLA")
+
+    assert result["agent"] == "RiskAdvisorAgent"
+    assert result["symbol"] == "TSLA"
+    assert result["assessment"] == response_text
+
+
+def test_news_summarizer_agent_uses_prompt_template():
+    response_text = "News summary"
+    fake_call = MagicMock(return_value=response_text)
+    with patch("trading_bot.openai_client.call_openai", fake_call):
+        template = "Summarize news for {symbol}"
+        agent = NewsSummarizerAgent(prompt_template=template)
+        result = agent.summarize("GOOG")
+        fake_call.assert_called_once_with("Summarize news for GOOG")
+
+    assert result["agent"] == "NewsSummarizerAgent"
+    assert result["symbol"] == "GOOG"
+    assert result["summary"] == response_text

--- a/trading_bot/agents/__init__.py
+++ b/trading_bot/agents/__init__.py
@@ -1,6 +1,12 @@
 """Agents package exposes available agent classes."""
 
 from .llm_agent import LLMAgent
+from .llm_roles import MarketAnalystAgent, NewsSummarizerAgent, RiskAdvisorAgent
 
-__all__ = ["LLMAgent"]
+__all__ = [
+    "LLMAgent",
+    "MarketAnalystAgent",
+    "RiskAdvisorAgent",
+    "NewsSummarizerAgent",
+]
 

--- a/trading_bot/agents/llm_roles.py
+++ b/trading_bot/agents/llm_roles.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+"""Specialized LLM-backed agents for different market research roles."""
+
+from typing import Dict
+
+
+class MarketAnalystAgent:
+    """Generate market analysis for a ticker symbol."""
+
+    def __init__(self, prompt_template: str = "Provide a market analysis for {symbol}.") -> None:
+        self.prompt_template = prompt_template
+
+    def analyze(self, symbol: str) -> Dict[str, str]:
+        """Return a market analysis for ``symbol`` using an LLM."""
+        try:  # Import lazily so missing dependencies don't break module import.
+            from trading_bot import openai_client
+        except Exception as exc:  # pragma: no cover - exercised when dependency missing
+            raise ImportError(
+                "openai_client (and openai) must be available to use MarketAnalystAgent"
+            ) from exc
+
+        prompt = self.prompt_template.format(symbol=symbol)
+        raw_response = openai_client.call_openai(prompt)
+
+        return {
+            "agent": "MarketAnalystAgent",
+            "symbol": symbol,
+            "analysis": raw_response,
+        }
+
+
+class RiskAdvisorAgent:
+    """Assess investment risks for a ticker symbol."""
+
+    def __init__(
+        self, prompt_template: str = "Offer an investment risk assessment for {symbol}."
+    ) -> None:
+        self.prompt_template = prompt_template
+
+    def assess(self, symbol: str) -> Dict[str, str]:
+        """Return a risk assessment for ``symbol`` using an LLM."""
+        try:  # Import lazily so missing dependencies don't break module import.
+            from trading_bot import openai_client
+        except Exception as exc:  # pragma: no cover - exercised when dependency missing
+            raise ImportError(
+                "openai_client (and openai) must be available to use RiskAdvisorAgent"
+            ) from exc
+
+        prompt = self.prompt_template.format(symbol=symbol)
+        raw_response = openai_client.call_openai(prompt)
+
+        return {
+            "agent": "RiskAdvisorAgent",
+            "symbol": symbol,
+            "assessment": raw_response,
+        }
+
+
+class NewsSummarizerAgent:
+    """Summarize recent news for a ticker symbol."""
+
+    def __init__(
+        self, prompt_template: str = "Summarize the latest financial news affecting {symbol}."
+    ) -> None:
+        self.prompt_template = prompt_template
+
+    def summarize(self, symbol: str) -> Dict[str, str]:
+        """Return a news summary for ``symbol`` using an LLM."""
+        try:  # Import lazily so missing dependencies don't break module import.
+            from trading_bot import openai_client
+        except Exception as exc:  # pragma: no cover - exercised when dependency missing
+            raise ImportError(
+                "openai_client (and openai) must be available to use NewsSummarizerAgent"
+            ) from exc
+
+        prompt = self.prompt_template.format(symbol=symbol)
+        raw_response = openai_client.call_openai(prompt)
+
+        return {
+            "agent": "NewsSummarizerAgent",
+            "symbol": symbol,
+            "summary": raw_response,
+        }
+
+
+__all__ = ["MarketAnalystAgent", "RiskAdvisorAgent", "NewsSummarizerAgent"]


### PR DESCRIPTION
## Summary
- add MarketAnalystAgent, RiskAdvisorAgent, NewsSummarizerAgent with configurable prompt templates
- expose new agents from the agents package
- test that each agent formats prompts and delegates to OpenAI client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6892340d89108332950b76e03bfdbcea