### PR TITLE
Add coordinator orchestrating agent dialogue

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,25 +1,43 @@
-from unittest.mock import patch
-
-from trading_bot.agents import LLMAgent
+from trading_bot.coordinator import Coordinator
 from trading_bot.pipeline import Pipeline
 
 
-def test_pipeline_returns_only_llmagent_reports():
-    agents = [LLMAgent(), LLMAgent()]
-    with patch.object(
-        LLMAgent,
-        "analyze",
-        side_effect=lambda symbol: {
-            "agent": "LLMAgent",
-            "symbol": symbol,
-            "summary": "stub",
-            "raw_response": "raw",
-        },
-    ) as mock_analyze:
-        pipeline = Pipeline(agents)
-        result = pipeline.run("TSLA")
-        assert mock_analyze.call_count == 2
+class DummyAgent:
+    def __init__(self, name, message, question=None):
+        self.name = name
+        self.message = message
+        self.question = question
+        self.received_history = None
 
-    assert result["symbol"] == "TSLA"
-    assert len(result["reports"]) == 2
-    assert all(report["agent"] == "LLMAgent" for report in result["reports"])
+    def respond(self, symbol, history):
+        # store history to assert later
+        self.received_history = list(history)
+        response = {"message": f"{self.message} {symbol}"}
+        if self.question:
+            response["question"] = self.question
+        return response
+
+
+def test_agents_exchange_messages_and_final_decision_composed():
+    analyst = DummyAgent("Analyst", "analysis for", question="need more data?")
+    trader = DummyAgent("Trader", "decision for")
+
+    coordinator = Coordinator([analyst, trader])
+    pipeline = Pipeline(coordinator)
+    result = pipeline.run("TSLA")
+
+    # first agent receives empty history
+    assert analyst.received_history == []
+    # second agent sees first agent's message
+    assert trader.received_history == [
+        {"agent": "Analyst", "message": "analysis for TSLA"}
+    ]
+
+    assert result["conversation"] == [
+        {"agent": "Analyst", "message": "analysis for TSLA"},
+        {"agent": "Trader", "message": "decision for TSLA"},
+    ]
+    assert result["follow_ups"] == [
+        {"agent": "Analyst", "question": "need more data?"}
+    ]
+    assert result["final_decision"] == "decision for TSLA"

--- a/trading_bot/coordinator.py
+++ b/trading_bot/coordinator.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""Simple conversation coordinator for multiple role agents.
+
+The :class:`Coordinator` orchestrates a sequential conversation between a list
+of agents.  Each agent receives the conversation history so far and may return
+both a message and an optional follow-up question.  The coordinator aggregates
+these exchanges and exposes the full conversation along with any questions and
+the final decision.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence
+
+
+@dataclass
+class Coordinator:
+    """Coordinate dialogue between role specific agents."""
+
+    agents: Sequence[Any]
+
+    def run(self, symbol: str) -> Dict[str, Any]:
+        """Run a conversation between all agents.
+
+        Parameters
+        ----------
+        symbol:
+            The market symbol the agents should discuss.
+        Returns
+        -------
+        dict
+            Dictionary containing the conversation history, any follow-up
+            questions raised by agents and the final decision produced by the
+            last agent.
+        """
+        history: List[Dict[str, str]] = []
+        follow_ups: List[Dict[str, str]] = []
+
+        for agent in self.agents:
+            response: Dict[str, str] = agent.respond(symbol, history)
+            agent_name = getattr(agent, "name", agent.__class__.__name__)
+            message = response.get("message", "")
+            history.append({"agent": agent_name, "message": message})
+            question = response.get("question")
+            if question:
+                follow_ups.append({"agent": agent_name, "question": question})
+
+        final_decision = history[-1]["message"] if history else ""
+        return {
+            "symbol": symbol,
+            "conversation": history,
+            "follow_ups": follow_ups,
+            "final_decision": final_decision,
+        }
+
+
+__all__ = ["Coordinator"]

--- a/trading_bot/pipeline.py
+++ b/trading_bot/pipeline.py
@@ -1,30 +1,22 @@
-"""Minimal pipeline orchestrating LLMAgents.
-
-The pipeline accepts a sequence of :class:`~trading_bot.agents.LLMAgent`
-instances. When run for a symbol it executes each agent and aggregates their
-responses into a single dictionary.
-
-This stripped down version intentionally focuses on LLM driven analysis.
-"""
+"""Minimal pipeline orchestrating role agents via the Coordinator."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Sequence
+from typing import Any, Dict
 
-from .agents import LLMAgent
+from .coordinator import Coordinator
 
 
 @dataclass
 class Pipeline:
-    """Run all configured LLM agents for a given symbol."""
+    """Pipeline delegating orchestration to :class:`Coordinator`."""
 
-    agents: Sequence[LLMAgent]
+    coordinator: Coordinator
 
     def run(self, symbol: str) -> Dict[str, Any]:
-        """Execute each agent and collect their outputs."""
-        reports: List[Dict[str, Any]] = [agent.analyze(symbol) for agent in self.agents]
-        return {"symbol": symbol, "reports": reports}
+        """Execute the coordinator for ``symbol`` and return its output."""
+        return self.coordinator.run(symbol)
 
 
 __all__ = ["Pipeline"]


### PR DESCRIPTION
## Summary
- add conversation Coordinator to pass history through role agents and collect follow-up questions
- refactor Pipeline to delegate work to Coordinator
- test conversation flow and final decision assembly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_689237bc73d08332ba7109db31fbe769