### PR TITLE
docs: describe role-based agents and add coordinator demo

### DIFF
--- a/notebooks/role_coordinator_demo.ipynb
+++ b/notebooks/role_coordinator_demo.ipynb
@@ -1,0 +1,54 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ensure the OPENAI_API_KEY env var is set before running.\n",
+    "from trading_bot.coordinator import Coordinator\n",
+    "from trading_bot.agents.llm_roles import (\n",
+    "    MarketAnalystAgent,\n",
+    "    RiskAdvisorAgent,\n",
+    "    NewsSummarizerAgent,\n",
+    ")\n",
+    "\n",
+    "class Analyst:\n",
+    "    name = \"Analyst\"\n",
+    "    def respond(self, symbol, history):\n",
+    "        res = MarketAnalystAgent().analyze(symbol)\n",
+    "        return {\"message\": res[\"analysis\"]}\n",
+    "\n",
+    "class Risk:\n",
+    "    name = \"RiskAdvisor\"\n",
+    "    def respond(self, symbol, history):\n",
+    "        res = RiskAdvisorAgent().assess(symbol)\n",
+    "        return {\"message\": res[\"assessment\"]}\n",
+    "\n",
+    "class News:\n",
+    "    name = \"NewsSummarizer\"\n",
+    "    def respond(self, symbol, history):\n",
+    "        res = NewsSummarizerAgent().summarize(symbol)\n",
+    "        return {\"message\": res[\"summary\"]}\n",
+    "\n",
+    "coordinator = Coordinator([Analyst(), Risk(), News()])\n",
+    "coordinator.run(\"TSLA\")\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.x"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}
+


### PR DESCRIPTION
## Summary
- describe new role-based OpenAI agents and coordinator flow in the README
- document required OPENAI_API_KEY and remove outdated Gemini/rule-based references
- add `role_coordinator_demo.ipynb` showing multiple roles analyzing a symbol

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68923b97773c83329840529bcd5bac37