### PR TITLE
Refactor trading pipeline demo to use coordinator wrappers

### DIFF
--- a/notebooks/trading_pipeline_demo.ipynb
+++ b/notebooks/trading_pipeline_demo.ipynb
@@ -17,13 +17,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from trading_bot.coordinator import Coordinator\n",
     "from trading_bot.agents import (\n",
-    "    TechnicalAnalysisAgent, MarketScannerAgent,\n",
-    "    SocialMediaAgent, NewsAnalyzerAgent,\n",
+    "    MarketAnalystAgent,\n",
+    "    RiskAdvisorAgent,\n",
+    "    NewsSummarizerAgent,\n",
     ")\n",
-    "from trading_bot.pipeline import Pipeline\n",
-    "from trading_bot.storage import JSONStorage\n",
-    "from trading_bot.portfolio import Portfolio\n"
+    "from trading_bot.pipeline import Pipeline\n"
    ]
   },
   {
@@ -33,12 +33,34 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "agents = [TechnicalAnalysisAgent(), MarketScannerAgent(),\n",
-    "          SocialMediaAgent(), NewsAnalyzerAgent()]\n",
-    "pipeline = Pipeline(agents, storage=JSONStorage(\"data\"),\n",
-    "                    portfolio=Portfolio())\n",
-    "result = pipeline.run_for_symbol(\"TSLA\")\n",
-    "result[\"strategy\"]\n"
+    "class Analyst:\n",
+    "    def __init__(self):\n",
+    "        self.agent = MarketAnalystAgent()\n",
+    "\n",
+    "    def respond(self, symbol, history):\n",
+    "        result = self.agent.analyze(symbol)\n",
+    "        return {\"message\": result.get(\"analysis\", \"\")}\n",
+    "\n",
+    "class Risk:\n",
+    "    def __init__(self):\n",
+    "        self.agent = RiskAdvisorAgent()\n",
+    "\n",
+    "    def respond(self, symbol, history):\n",
+    "        result = self.agent.assess(symbol)\n",
+    "        return {\"message\": result.get(\"assessment\", \"\")}\n",
+    "\n",
+    "class News:\n",
+    "    def __init__(self):\n",
+    "        self.agent = NewsSummarizerAgent()\n",
+    "\n",
+    "    def respond(self, symbol, history):\n",
+    "        result = self.agent.summarize(symbol)\n",
+    "        return {\"message\": result.get(\"summary\", \"\")}\n",
+    "\n",
+    "coordinator = Coordinator([Analyst(), Risk(), News()])\n",
+    "pipeline = Pipeline(coordinator)\n",
+    "result = pipeline.run(\"TSLA\")\n",
+    "result[\"final_decision\"]\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- Replace legacy agents with Coordinator and new LLM-backed agents in trading_pipeline_demo notebook
- Wrap agents with simple `respond` interfaces and run pipeline via `pipeline.run("TSLA")`
- Remove unused JSONStorage and Portfolio references

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_689249cdcb808332bd440c3a8169f29d