### PR TITLE
Ensure OpenAI API key is loaded or prompted

### DIFF
--- a/notebooks/trading_pipeline_demo.ipynb
+++ b/notebooks/trading_pipeline_demo.ipynb
@@ -28,28 +28,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "d1e73c2d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "✅ Loaded: False\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import os\n",
-    "from dotenv import load_dotenv\n",
+    "from trading_bot.openai_client import ensure_api_key\n",
     "\n",
-    "# Make sure to point to the correct .env file in the root directory\n",
-    "load_dotenv(dotenv_path=\"../.env\")\n",
-    "\n",
-    "# Optional: check if it's working\n",
-    "print(\"✅ Loaded:\", os.getenv(\"OPENAI_API_KEY\") is not None)\n",
-    "\n"
+    "# Load the API key from .env or prompt the user\n",
+    "ensure_api_key()\n"
    ]
   },
   {

--- a/trading_bot/openai_client.py
+++ b/trading_bot/openai_client.py
@@ -3,13 +3,22 @@
 from __future__ import annotations
 
 import os
+from getpass import getpass
 from typing import Any
 
+from dotenv import load_dotenv
 import openai
 try:  # pragma: no cover - import path differs between OpenAI versions
     from openai.error import OpenAIError, RateLimitError
 except Exception:  # pragma: no cover
     from openai import OpenAIError, RateLimitError
+
+
+def ensure_api_key() -> None:
+    """Load ``OPENAI_API_KEY`` from ``.env`` or prompt the user."""
+    load_dotenv()
+    if not os.getenv("OPENAI_API_KEY"):
+        os.environ["OPENAI_API_KEY"] = getpass("Enter OpenAI API key: ")
 
 
 def call_openai(prompt: str, *, temperature: float = 0.7) -> str:
@@ -34,6 +43,8 @@ def call_openai(prompt: str, *, temperature: float = 0.7) -> str:
     RuntimeError
         If the OpenAI API returns an error.
     """
+    ensure_api_key()
+
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
         raise ValueError("OPENAI_API_KEY environment variable is not set")
@@ -54,4 +65,4 @@ def call_openai(prompt: str, *, temperature: float = 0.7) -> str:
     return response.choices[0].message["content"].strip()
 
 
-__all__ = ["call_openai"]
+__all__ = ["call_openai", "ensure_api_key"]


### PR DESCRIPTION
## Summary
- add `ensure_api_key` helper that loads `.env` and prompts for the OpenAI API key if missing
- use `ensure_api_key` in `call_openai`
- invoke `ensure_api_key` from `trading_pipeline_demo.ipynb` before agent setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_68927c9fdee08332ab934b24bdf24b78