### PR TITLE
Refactor OpenAI client usage

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -10,13 +10,19 @@ from trading_bot import openai_client
 
 def test_call_openai_success():
     fake_response = types.SimpleNamespace(
-        choices=[types.SimpleNamespace(message={"content": "hello world"})]
+        choices=[
+            types.SimpleNamespace(
+                message=types.SimpleNamespace(content="hello world")
+            )
+        ]
     )
     with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
-        with patch("openai.ChatCompletion.create", return_value=fake_response) as mock_create:
+        with patch("trading_bot.openai_client.OpenAI") as MockOpenAI:
+            mock_client = MockOpenAI.return_value
+            mock_client.chat.completions.create.return_value = fake_response
             result = openai_client.call_openai("hi", temperature=0.2)
     assert result == "hello world"
-    mock_create.assert_called_once_with(
+    mock_client.chat.completions.create.assert_called_once_with(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": "hi"}],
         temperature=0.2,
@@ -25,7 +31,9 @@ def test_call_openai_success():
 
 def test_call_openai_raises_runtime_error_on_openaierror():
     with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
-        with patch("openai.ChatCompletion.create", side_effect=OpenAIError("boom")):
+        with patch("trading_bot.openai_client.OpenAI") as MockOpenAI:
+            mock_client = MockOpenAI.return_value
+            mock_client.chat.completions.create.side_effect = OpenAIError("boom")
             with pytest.raises(RuntimeError):
                 openai_client.call_openai("hi")
 
@@ -35,7 +43,9 @@ def test_call_openai_raises_runtime_error_on_ratelimit():
         pass
 
     with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
-        with patch("openai.ChatCompletion.create", side_effect=DummyRateLimitError):
+        with patch("trading_bot.openai_client.OpenAI") as MockOpenAI:
+            mock_client = MockOpenAI.return_value
+            mock_client.chat.completions.create.side_effect = DummyRateLimitError
             with patch("trading_bot.openai_client.RateLimitError", DummyRateLimitError):
                 with pytest.raises(RuntimeError, match="rate limit"):
                     openai_client.call_openai("hi")

--- a/trading_bot/openai_client.py
+++ b/trading_bot/openai_client.py
@@ -3,18 +3,10 @@
 from __future__ import annotations
 
 import os
-import sys
-from getpass import getpass
-from typing import Any
+from pathlib import Path
 
 from dotenv import load_dotenv
-import openai
-try:  # pragma: no cover - import path differs between OpenAI versions
-    from openai.error import OpenAIError, RateLimitError
-except Exception:  # pragma: no cover
-    from openai import OpenAIError, RateLimitError
-
-from pathlib import Path
+from openai import OpenAI, OpenAIError, RateLimitError
 
 def ensure_api_key() -> None:
     """Load ``OPENAI_API_KEY`` from ``.env`` or prompt the user."""
@@ -58,10 +50,10 @@ def call_openai(prompt: str, *, temperature: float = 0.7) -> str:
     if not api_key:
         raise ValueError("OPENAI_API_KEY environment variable is not set")
 
-    openai.api_key = api_key
+    client = OpenAI(api_key=api_key)
 
     try:
-        response: Any = openai.ChatCompletion.create(
+        response = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,
@@ -71,7 +63,7 @@ def call_openai(prompt: str, *, temperature: float = 0.7) -> str:
     except OpenAIError as exc:
         raise RuntimeError(f"OpenAI API error: {exc}") from exc
 
-    return response.choices[0].message["content"].strip()
+    return response.choices[0].message.content.strip()
 
 
 __all__ = ["call_openai", "ensure_api_key"]


### PR DESCRIPTION
## Summary
- migrate OpenAI calls to new `OpenAI` client
- adjust tests for new client usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68928cadc3948332aa42e1868de5d64b