### PR TITLE
test: mock OpenAI client in unit tests

### DIFF
--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -13,10 +13,11 @@ def test_call_openai_success():
         choices=[types.SimpleNamespace(message={"content": "hello world"})]
     )
     with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
-        with patch("openai.ChatCompletion.create", return_value=fake_response) as mock_create:
+        with patch("trading_bot.openai_client.OpenAI") as MockClient:
+            MockClient.return_value.chat.completions.create.return_value = fake_response
             result = openai_client.call_openai("hi", temperature=0.2)
     assert result == "hello world"
-    mock_create.assert_called_once_with(
+    MockClient.return_value.chat.completions.create.assert_called_once_with(
         model="gpt-3.5-turbo",
         messages=[{"role": "user", "content": "hi"}],
         temperature=0.2,
@@ -25,7 +26,8 @@ def test_call_openai_success():
 
 def test_call_openai_raises_runtime_error_on_openaierror():
     with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
-        with patch("openai.ChatCompletion.create", side_effect=OpenAIError("boom")):
+        with patch("trading_bot.openai_client.OpenAI") as MockClient:
+            MockClient.return_value.chat.completions.create.side_effect = OpenAIError("boom")
             with pytest.raises(RuntimeError):
                 openai_client.call_openai("hi")
 
@@ -35,7 +37,8 @@ def test_call_openai_raises_runtime_error_on_ratelimit():
         pass
 
     with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
-        with patch("openai.ChatCompletion.create", side_effect=DummyRateLimitError):
+        with patch("trading_bot.openai_client.OpenAI") as MockClient:
+            MockClient.return_value.chat.completions.create.side_effect = DummyRateLimitError
             with patch("trading_bot.openai_client.RateLimitError", DummyRateLimitError):
                 with pytest.raises(RuntimeError, match="rate limit"):
                     openai_client.call_openai("hi")

--- a/trading_bot/openai_client.py
+++ b/trading_bot/openai_client.py
@@ -1,4 +1,4 @@
-"""Lightweight wrapper around OpenAI's ChatCompletion API."""
+"""Lightweight wrapper around OpenAI's chat completions API."""
 
 from __future__ import annotations
 
@@ -8,11 +8,7 @@ from getpass import getpass
 from typing import Any
 
 from dotenv import load_dotenv
-import openai
-try:  # pragma: no cover - import path differs between OpenAI versions
-    from openai.error import OpenAIError, RateLimitError
-except Exception:  # pragma: no cover
-    from openai import OpenAIError, RateLimitError
+from openai import OpenAI, OpenAIError, RateLimitError
 
 from pathlib import Path
 
@@ -58,10 +54,10 @@ def call_openai(prompt: str, *, temperature: float = 0.7) -> str:
     if not api_key:
         raise ValueError("OPENAI_API_KEY environment variable is not set")
 
-    openai.api_key = api_key
+    client = OpenAI(api_key=api_key)
 
     try:
-        response: Any = openai.ChatCompletion.create(
+        response: Any = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[{"role": "user", "content": prompt}],
             temperature=temperature,


### PR DESCRIPTION
## Summary
- Use OpenAI client in `openai_client.call_openai` and adjust tests
- Patch `OpenAI` in tests to return mocked chat completions responses

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68928cb1ea6c833295f57333937b546c