### PR TITLE
Refactor pipeline for structured agents and local LLM

### DIFF
--- a/tests/test_llm_agent.py
+++ b/tests/test_llm_agent.py
@@ -6,7 +6,7 @@ from trading_bot.agents import LLMAgent
 def test_llmagent_calls_openai_and_structures_output():
     response_text = "Bullish outlook on TSLA\nFurther details here"
     fake_call = MagicMock(return_value=response_text)
-    with patch("trading_bot.openai_client.call_openai", fake_call):
+    with patch("trading_bot.openai_client.call_llm", fake_call):
         agent = LLMAgent()
         result = agent.analyze("TSLA")
         fake_call.assert_called_once()

--- a/tests/test_llm_roles.py
+++ b/tests/test_llm_roles.py
@@ -1,49 +1,50 @@
+import json
 from unittest.mock import MagicMock, patch
 
 from trading_bot.agents import (
     MarketAnalystAgent,
-    NewsSummarizerAgent,
     RiskAdvisorAgent,
+    NewsSummarizerAgent,
 )
 
 
-def test_market_analyst_agent_uses_prompt_template():
-    response_text = "Analysis result"
-    fake_call = MagicMock(return_value=response_text)
-    with patch("trading_bot.openai_client.call_openai", fake_call):
-        template = "Analyze the market for {symbol}"
-        agent = MarketAnalystAgent(prompt_template=template)
-        result = agent.analyze("AAPL")
-        fake_call.assert_called_once_with("Analyze the market for AAPL")
+def test_market_analyst_agent_returns_structured_data():
+    response = json.dumps(
+        {"summary": "s", "reasoning": "r", "market_trend": "up"}
+    )
+    fake = MagicMock(return_value=response)
+    with patch("trading_bot.openai_client.call_llm", fake):
+        agent = MarketAnalystAgent()
+        data = agent.analyze("AAPL")
 
-    assert result["agent"] == "MarketAnalystAgent"
-    assert result["symbol"] == "AAPL"
-    assert result["analysis"] == response_text
-
-
-def test_risk_advisor_agent_uses_prompt_template():
-    response_text = "Risk assessment"
-    fake_call = MagicMock(return_value=response_text)
-    with patch("trading_bot.openai_client.call_openai", fake_call):
-        template = "Assess risks for {symbol}"
-        agent = RiskAdvisorAgent(prompt_template=template)
-        result = agent.assess("TSLA")
-        fake_call.assert_called_once_with("Assess risks for TSLA")
-
-    assert result["agent"] == "RiskAdvisorAgent"
-    assert result["symbol"] == "TSLA"
-    assert result["assessment"] == response_text
+    fake.assert_called_once()
+    assert data["summary"] == "s"
+    assert data["reasoning"] == "r"
+    assert data["market_trend"] == "up"
 
 
-def test_news_summarizer_agent_uses_prompt_template():
-    response_text = "News summary"
-    fake_call = MagicMock(return_value=response_text)
-    with patch("trading_bot.openai_client.call_openai", fake_call):
-        template = "Summarize news for {symbol}"
-        agent = NewsSummarizerAgent(prompt_template=template)
-        result = agent.summarize("GOOG")
-        fake_call.assert_called_once_with("Summarize news for GOOG")
+def test_risk_advisor_agent_returns_structured_data():
+    response = json.dumps(
+        {"summary": "s", "reasoning": "r", "risk_level": "low"}
+    )
+    fake = MagicMock(return_value=response)
+    with patch("trading_bot.openai_client.call_llm", fake):
+        agent = RiskAdvisorAgent()
+        data = agent.assess("TSLA")
 
-    assert result["agent"] == "NewsSummarizerAgent"
-    assert result["symbol"] == "GOOG"
-    assert result["summary"] == response_text
+    assert data["risk_level"] == "low"
+    assert data["agent"] == "RiskAdvisorAgent"
+
+
+def test_news_summarizer_agent_returns_structured_data():
+    response = json.dumps(
+        {"summary": "s", "reasoning": "r", "headlines": ["h1"]}
+    )
+    fake = MagicMock(return_value=response)
+    with patch("trading_bot.openai_client.call_llm", fake):
+        agent = NewsSummarizerAgent()
+        data = agent.summarize("GOOG")
+
+    assert data["headlines"] == ["h1"]
+    assert data["agent"] == "NewsSummarizerAgent"
+

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,51 +1,24 @@
-from unittest.mock import patch
-import os
+from unittest.mock import MagicMock, patch
 import types
-
-import pytest
-from openai import OpenAIError
+import sys
 
 from trading_bot import openai_client
 
 
-def test_call_openai_success():
-    fake_response = types.SimpleNamespace(
-        choices=[
-            types.SimpleNamespace(
-                message=types.SimpleNamespace(content="hello world")
-            )
-        ]
-    )
-    with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
-        with patch("trading_bot.openai_client.OpenAI") as MockOpenAI:
-            mock_client = MockOpenAI.return_value
-            mock_client.chat.completions.create.return_value = fake_response
-            result = openai_client.call_openai("hi", temperature=0.2)
-    assert result == "hello world"
-    mock_client.chat.completions.create.assert_called_once_with(
-        model="gpt-3.5-turbo",
-        messages=[{"role": "user", "content": "hi"}],
-        temperature=0.2,
-    )
+def test_call_llm_uses_loaded_generator(monkeypatch):
+    fake_gen = MagicMock(return_value="output")
+    monkeypatch.setattr(openai_client, "_load_generator", lambda: fake_gen)
+
+    result = openai_client.call_llm("prompt", temperature=0.2)
+
+    assert result == "output"
+    fake_gen.assert_called_once_with("prompt", temperature=0.2)
 
 
-def test_call_openai_raises_runtime_error_on_openaierror():
-    with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
-        with patch("trading_bot.openai_client.OpenAI") as MockOpenAI:
-            mock_client = MockOpenAI.return_value
-            mock_client.chat.completions.create.side_effect = OpenAIError("boom")
-            with pytest.raises(RuntimeError):
-                openai_client.call_openai("hi")
+def test_call_llm_falls_back_when_transformers_missing():
+    dummy_module = types.SimpleNamespace(pipeline=MagicMock(side_effect=Exception("boom")))
+    with patch.dict(sys.modules, {"transformers": dummy_module}):
+        openai_client._GENERATOR = None
+        result = openai_client.call_llm("hi")
+    assert result == "hi"
 
-
-def test_call_openai_raises_runtime_error_on_ratelimit():
-    class DummyRateLimitError(Exception):
-        pass
-
-    with patch.dict(os.environ, {"OPENAI_API_KEY": "key"}, clear=True):
-        with patch("trading_bot.openai_client.OpenAI") as MockOpenAI:
-            mock_client = MockOpenAI.return_value
-            mock_client.chat.completions.create.side_effect = DummyRateLimitError
-            with patch("trading_bot.openai_client.RateLimitError", DummyRateLimitError):
-                with pytest.raises(RuntimeError, match="rate limit"):
-                    openai_client.call_openai("hi")

--- a/trading_bot/agents/llm_agent.py
+++ b/trading_bot/agents/llm_agent.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-"""Lightweight agent that queries an LLM for market commentary.
+"""Lightweight agent that queries a local LLM for market commentary.
 
-The agent relies on :mod:`trading_bot.openai_client` to interact with OpenAI's
-API.  The text response from the model is wrapped into a small structured
-dictionary so it fits the common interface used across the project.
+The agent relies on :mod:`trading_bot.openai_client` which in turn utilises a
+small open-source model.  The text response from the model is wrapped into a
+small structured dictionary so it fits the common interface used across the
+project.
 """
 
 from typing import Dict
@@ -17,7 +18,7 @@ class LLMAgent:
         """Return an LLM-generated summary for ``symbol``.
 
         The method crafts a prompt referencing ``symbol`` and delegates the
-        request to :func:`trading_bot.openai_client.call_openai`.  The raw text
+        request to :func:`trading_bot.openai_client.call_llm`.  The raw text
         reply from the model is packaged into a simple dictionary alongside a
         one-line summary extracted from the response.
         """
@@ -30,7 +31,7 @@ class LLMAgent:
             ) from exc
 
         prompt = f"Provide a concise investment summary for the stock symbol {symbol}."
-        raw_response = openai_client.call_openai(prompt)
+        raw_response = openai_client.call_llm(prompt)
         summary = raw_response.strip().splitlines()[0] if raw_response else ""
 
         return {

--- a/trading_bot/backtest.py
+++ b/trading_bot/backtest.py
@@ -27,6 +27,7 @@ class Backtester:
         start_date: str,
         end_date: str,
         strategy_dict: Dict[str, Any],
+        portfolio: Any | None = None,
     ) -> Dict[str, Any]:
         try:
             import yfinance as yf  # type: ignore
@@ -62,7 +63,7 @@ class Backtester:
             }
         ]
 
-        return {
+        result = {
             "symbol": symbol,
             "date_range": [start_date, end_date],
             "net_return": net_return,
@@ -73,6 +74,24 @@ class Backtester:
             "agent_inputs": {},
             "data_source": self.data_source,
         }
+
+        if portfolio is not None:  # pragma: no cover - simple integration hook
+            from datetime import datetime
+
+            entry = portfolio.open_position(
+                symbol,
+                size=1,
+                entry_price=float(prices.iloc[0]),
+                entry_time=datetime.fromisoformat(start_date + "T00:00:00"),
+                strategy_ref="backtest",
+            )
+            portfolio.close_position(
+                entry,
+                exit_price=float(prices.iloc[-1]),
+                exit_time=datetime.fromisoformat(end_date + "T00:00:00"),
+            )
+
+        return result
 
 
 __all__: List[str] = ["Backtester"]

--- a/trading_bot/pipeline.py
+++ b/trading_bot/pipeline.py
@@ -1,22 +1,114 @@
-"""Minimal pipeline orchestrating role agents via the Coordinator."""
+"""Pipeline executing agents over a date range and persisting results."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional
+
+import pandas as pd
 
 from .coordinator import Coordinator
+from .strategy import compose_strategy
+from .storage import JSONStorage
+from .backtest import Backtester
+from .portfolio import Portfolio
 
 
 @dataclass
 class Pipeline:
-    """Pipeline delegating orchestration to :class:`Coordinator`."""
+    """Coordinate agents and optionally backtest their combined strategy."""
 
     coordinator: Coordinator
+    storage: JSONStorage
+    backtester: Optional[Backtester] = None
+    portfolio: Optional[Portfolio] = None
 
-    def run(self, symbol: str) -> Dict[str, Any]:
-        """Execute the coordinator for ``symbol`` and return its output."""
-        return self.coordinator.run(symbol)
+    def _date_iter(self, start: str, end: str) -> Iterable[pd.Timestamp]:
+        return pd.date_range(start, end, freq="D")
+
+    def run(
+        self,
+        symbol: str,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        today: str | None = None,
+    ) -> Dict[str, Any]:
+        """Run the pipeline for ``symbol``.
+
+        If ``today`` is supplied only that date is processed and the composed
+        strategy for the day is returned.  Otherwise the function iterates from
+        ``start_date`` to ``end_date`` (inclusive), logging each day's
+        conversation and strategy and optionally invoking a backtest across the
+        whole range.
+        """
+
+        if today:
+            dates = [pd.to_datetime(today)]
+        else:
+            if start_date is None or end_date is None:
+                raise ValueError("start_date and end_date must be provided when today is not set")
+            dates = list(self._date_iter(start_date, end_date))
+
+        day_results: List[Dict[str, Any]] = []
+
+        for ts in dates:
+            day_str = ts.strftime("%Y-%m-%d")
+            convo = self.coordinator.run(symbol)
+            convo_path = self.storage.save("conversation", symbol, day_str, convo)
+
+            agent_map = {item["agent"]: item for item in convo["conversation"]}
+            strategy = compose_strategy(symbol, agent_map, strategy_date=day_str)
+            strat_path = self.storage.save("strategy", symbol, day_str, strategy)
+
+            if self.portfolio is not None:
+                entry_price = 100.0
+                pos = self.portfolio.open_position(
+                    symbol,
+                    size=1,
+                    entry_price=entry_price,
+                    entry_time=datetime.fromisoformat(day_str + "T00:00:00"),
+                    strategy_ref=day_str,
+                )
+                self.portfolio.close_position(
+                    pos,
+                    exit_price=entry_price,
+                    exit_time=datetime.fromisoformat(day_str + "T23:59:59"),
+                )
+
+            day_results.append(
+                {
+                    "date": day_str,
+                    "conversation_path": str(convo_path),
+                    "strategy_path": str(strat_path),
+                    "strategy": strategy,
+                }
+            )
+
+        if today:
+            return day_results[-1]["strategy"]
+
+        files = {
+            "conversations": [d["conversation_path"] for d in day_results],
+            "strategies": [d["strategy_path"] for d in day_results],
+        }
+
+        backtest_result = None
+        if self.backtester is not None:
+            backtest_result = self.backtester.backtest(
+                symbol,
+                start_date=start_date or dates[0].strftime("%Y-%m-%d"),
+                end_date=end_date or dates[-1].strftime("%Y-%m-%d"),
+                strategy_dict={"strategies": [d["strategy"] for d in day_results]},
+                portfolio=self.portfolio,
+            )
+            bt_path = self.storage.save(
+                "backtest", symbol, dates[-1].strftime("%Y-%m-%d"), backtest_result
+            )
+            files["backtest"] = str(bt_path)
+
+        return {"days": day_results, "backtest": backtest_result, "files": files}
 
 
 __all__ = ["Pipeline"]
+

--- a/trading_bot/scheduler.py
+++ b/trading_bot/scheduler.py
@@ -8,7 +8,10 @@ specified time (default ``08:00`` Eastern).  The caller is responsible for
 shutting the scheduler down when the application exits.
 """
 
+from datetime import datetime
 from typing import Callable, Iterable
+
+from .pipeline import Pipeline
 
 
 def schedule_daily_run(
@@ -41,4 +44,23 @@ def schedule_daily_run(
     return scheduler
 
 
-__all__ = ["schedule_daily_run"]
+def run_daily_pipeline(
+    pipeline: Pipeline,
+    symbols: Iterable[str],
+    run_time: str = "08:00",
+    timezone: str = "US/Eastern",
+) -> BackgroundScheduler:
+    """Schedule :class:`Pipeline` to run once per day for each symbol.
+
+    The pipeline's :meth:`~trading_bot.pipeline.Pipeline.run` method is invoked
+    with ``today`` set to the execution date.
+    """
+
+    def job(sym: str) -> None:
+        today = datetime.now().strftime("%Y-%m-%d")
+        pipeline.run(sym, today=today)
+
+    return schedule_daily_run(job, symbols, run_time=run_time, timezone=timezone)
+
+
+__all__ = ["schedule_daily_run", "run_daily_pipeline"]

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -1,58 +1,37 @@
-"""Strategy composer for combining agent outputs into an actionable plan."""
+"""Utilities for composing a daily trading strategy."""
+
 from __future__ import annotations
 
 from datetime import date
-from typing import Any, Dict, Optional
+from typing import Dict, Any, Optional
 
 
 def compose_strategy(
-    symbol: str,
-    *,
-    technical: Optional[Dict[str, Any]] = None,
-    market: Optional[Dict[str, Any]] = None,
-    news: Optional[Dict[str, Any]] = None,
-    social: Optional[Dict[str, Any]] = None,
-    macro: Optional[Dict[str, Any]] = None,
-    strategy_date: Optional[str] = None,
+    symbol: str, agent_data: Dict[str, Dict[str, Any]], *, strategy_date: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Build a strategy dictionary from agent insights.
+    """Combine structured agent outputs into a simple action plan.
 
     Parameters
     ----------
     symbol:
-        Ticker symbol to which the strategy applies.
-    technical, market, news, social, macro:
-        Dictionaries produced by the corresponding agents.
+        The ticker symbol the strategy applies to.
+    agent_data:
+        Mapping of agent name to the structured dictionary each agent produced.
     strategy_date:
-        ISO formatted date.  Defaults to today if ``None``.
+        ISO formatted date for the strategy.  Defaults to today's date.
     """
 
     strategy_date = strategy_date or date.today().isoformat()
-    technical = technical or {"summary": "", "details": {}}
-    market = market or {"summary": "", "details": {}}
-    news = news or {"summary": "", "headlines": []}
-    social = social or {"summary": "", "score": 0}
-    macro = macro or {"summary": ""}
-
-    entry_criteria = f"Enter long on {symbol} when technicals support bullish trend."
-    position_sizing = "Risk 2% of capital per trade."
-    risk_management = "Set stop-loss below recent swing low."
-    exit_strategy = "Take profit at 2R or when momentum fades."
-    trade_management = "Move stop to break-even after 1R gain."
+    summary = " ".join(v.get("summary", "") for v in agent_data.values()).strip()
 
     return {
         "symbol": symbol,
         "date": strategy_date,
-        "entry_criteria": entry_criteria,
-        "position_sizing": position_sizing,
-        "risk_management": risk_management,
-        "exit_strategy": exit_strategy,
-        "trade_management": trade_management,
-        "rationale": {
-            "technical": {"summary": technical.get("summary", ""), "details": technical},
-            "market": market,
-            "news": news,
-            "social": social,
-            "macro": macro,
-        },
+        "summary": summary,
+        "details": agent_data,
+        "action": f"Review {symbol} with generated insights before trading.",
     }
+
+
+__all__ = ["compose_strategy"]
+


### PR DESCRIPTION
## Summary
- Replace OpenAI dependency with a local `transformers` based LLM wrapper and safe fallback
- Update market, risk and news agents to request/parse structured JSON and add respond hooks
- Rework coordinator, strategy composer and pipeline for daily strategies, storage and optional backtesting
- Add scheduler helper to run the pipeline daily via APScheduler

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6892b1fd2edc8332915bd6da8877b528