### PR TITLE
Refactor pipeline for structured strategies and local model support

### DIFF
--- a/notebooks/trading_pipeline_demo.ipynb
+++ b/notebooks/trading_pipeline_demo.ipynb
@@ -1,146 +1,95 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "87a6addf",
-   "metadata": {},
-   "source": [
-    "# Trading Pipeline Demo\n",
-    "\n",
-    "This notebook demonstrates how to run the trading pipeline with multiple agents to generate a strategy for a given ticker."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "id": "7d411fce",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "import os\n",
-    "\n",
-    "# Set the path to the project root so Python can find trading_bot/\n",
-    "project_root = os.path.abspath(os.path.join(os.getcwd(), '..'))\n",
-    "if project_root not in sys.path:\n",
-    "    sys.path.append(project_root)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "d1e73c2d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from trading_bot.env_loader import load_env_once\n",
-    "\n",
-    "load_env_once()\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "id": "23215d35",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from trading_bot.coordinator import Coordinator\n",
-    "from trading_bot.agents import (\n",
-    "    MarketAnalystAgent,\n",
-    "    RiskAdvisorAgent,\n",
-    "    NewsSummarizerAgent,\n",
-    ")\n",
-    "from trading_bot.pipeline import Pipeline\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "e2a79977",
-   "metadata": {},
-   "outputs": [
+  "cells": [
     {
-     "ename": "RuntimeError",
-     "evalue": "OpenAI API error: \n\nYou tried to access openai.ChatCompletion, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API.\n\nYou can run `openai migrate` to automatically upgrade your codebase to use the 1.0.0 interface. \n\nAlternatively, you can pin your installation to the old version, e.g. `pip install openai==0.28`\n\nA detailed migration guide is available here: https://github.com/openai/openai-python/discussions/742\n",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAPIRemovedInV1\u001b[0m                            Traceback (most recent call last)",
-      "File \u001b[0;32m~/Python_Code/AI-Trading-Agent/trading_bot/openai_client.py:64\u001b[0m, in \u001b[0;36mcall_openai\u001b[0;34m(prompt, temperature)\u001b[0m\n\u001b[1;32m     63\u001b[0m \u001b[38;5;28;01mtry\u001b[39;00m:\n\u001b[0;32m---> 64\u001b[0m     response: Any \u001b[38;5;241m=\u001b[39m \u001b[43mopenai\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mChatCompletion\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcreate\u001b[49m\u001b[43m(\u001b[49m\n\u001b[1;32m     65\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmodel\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mgpt-3.5-turbo\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\n\u001b[1;32m     66\u001b[0m \u001b[43m        \u001b[49m\u001b[43mmessages\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43m[\u001b[49m\u001b[43m{\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mrole\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43muser\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mcontent\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m:\u001b[49m\u001b[43m \u001b[49m\u001b[43mprompt\u001b[49m\u001b[43m}\u001b[49m\u001b[43m]\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     67\u001b[0m \u001b[43m        \u001b[49m\u001b[43mtemperature\u001b[49m\u001b[38;5;241;43m=\u001b[39;49m\u001b[43mtemperature\u001b[49m\u001b[43m,\u001b[49m\n\u001b[1;32m     68\u001b[0m \u001b[43m    \u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     69\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m RateLimitError \u001b[38;5;28;01mas\u001b[39;00m exc:\n",
-      "File \u001b[0;32m~/Python_Code/AI-Trading-Agent/.venv/lib/python3.9/site-packages/openai/lib/_old_api.py:39\u001b[0m, in \u001b[0;36mAPIRemovedInV1Proxy.__call__\u001b[0;34m(self, *_args, **_kwargs)\u001b[0m\n\u001b[1;32m     38\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21m__call__\u001b[39m(\u001b[38;5;28mself\u001b[39m, \u001b[38;5;241m*\u001b[39m_args: Any, \u001b[38;5;241m*\u001b[39m\u001b[38;5;241m*\u001b[39m_kwargs: Any) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Any:\n\u001b[0;32m---> 39\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m APIRemovedInV1(symbol\u001b[38;5;241m=\u001b[39m\u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39m_symbol)\n",
-      "\u001b[0;31mAPIRemovedInV1\u001b[0m: \n\nYou tried to access openai.ChatCompletion, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API.\n\nYou can run `openai migrate` to automatically upgrade your codebase to use the 1.0.0 interface. \n\nAlternatively, you can pin your installation to the old version, e.g. `pip install openai==0.28`\n\nA detailed migration guide is available here: https://github.com/openai/openai-python/discussions/742\n",
-      "\nThe above exception was the direct cause of the following exception:\n",
-      "\u001b[0;31mRuntimeError\u001b[0m                              Traceback (most recent call last)",
-      "Cell \u001b[0;32mIn[4], line 27\u001b[0m\n\u001b[1;32m     25\u001b[0m coordinator \u001b[38;5;241m=\u001b[39m Coordinator([Analyst(), Risk(), News()])\n\u001b[1;32m     26\u001b[0m pipeline \u001b[38;5;241m=\u001b[39m Pipeline(coordinator)\n\u001b[0;32m---> 27\u001b[0m result \u001b[38;5;241m=\u001b[39m \u001b[43mpipeline\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[38;5;124;43mTSLA\u001b[39;49m\u001b[38;5;124;43m\"\u001b[39;49m\u001b[43m)\u001b[49m\n\u001b[1;32m     28\u001b[0m result[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mfinal_decision\u001b[39m\u001b[38;5;124m\"\u001b[39m]\n",
-      "File \u001b[0;32m~/Python_Code/AI-Trading-Agent/trading_bot/pipeline.py:19\u001b[0m, in \u001b[0;36mPipeline.run\u001b[0;34m(self, symbol)\u001b[0m\n\u001b[1;32m     17\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mrun\u001b[39m(\u001b[38;5;28mself\u001b[39m, symbol: \u001b[38;5;28mstr\u001b[39m) \u001b[38;5;241m-\u001b[39m\u001b[38;5;241m>\u001b[39m Dict[\u001b[38;5;28mstr\u001b[39m, Any]:\n\u001b[1;32m     18\u001b[0m \u001b[38;5;250m    \u001b[39m\u001b[38;5;124;03m\"\"\"Execute the coordinator for ``symbol`` and return its output.\"\"\"\u001b[39;00m\n\u001b[0;32m---> 19\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcoordinator\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrun\u001b[49m\u001b[43m(\u001b[49m\u001b[43msymbol\u001b[49m\u001b[43m)\u001b[49m\n",
-      "File \u001b[0;32m~/Python_Code/AI-Trading-Agent/trading_bot/coordinator.py:40\u001b[0m, in \u001b[0;36mCoordinator.run\u001b[0;34m(self, symbol)\u001b[0m\n\u001b[1;32m     37\u001b[0m follow_ups: List[Dict[\u001b[38;5;28mstr\u001b[39m, \u001b[38;5;28mstr\u001b[39m]] \u001b[38;5;241m=\u001b[39m []\n\u001b[1;32m     39\u001b[0m \u001b[38;5;28;01mfor\u001b[39;00m agent \u001b[38;5;129;01min\u001b[39;00m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39magents:\n\u001b[0;32m---> 40\u001b[0m     response: Dict[\u001b[38;5;28mstr\u001b[39m, \u001b[38;5;28mstr\u001b[39m] \u001b[38;5;241m=\u001b[39m \u001b[43magent\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mrespond\u001b[49m\u001b[43m(\u001b[49m\u001b[43msymbol\u001b[49m\u001b[43m,\u001b[49m\u001b[43m \u001b[49m\u001b[43mhistory\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     41\u001b[0m     agent_name \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mgetattr\u001b[39m(agent, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mname\u001b[39m\u001b[38;5;124m\"\u001b[39m, agent\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__class__\u001b[39m\u001b[38;5;241m.\u001b[39m\u001b[38;5;18m__name__\u001b[39m)\n\u001b[1;32m     42\u001b[0m     message \u001b[38;5;241m=\u001b[39m response\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmessage\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m\"\u001b[39m)\n",
-      "Cell \u001b[0;32mIn[4], line 6\u001b[0m, in \u001b[0;36mAnalyst.respond\u001b[0;34m(self, symbol, history)\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[38;5;28;01mdef\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21mrespond\u001b[39m(\u001b[38;5;28mself\u001b[39m, symbol, history):\n\u001b[0;32m----> 6\u001b[0m     result \u001b[38;5;241m=\u001b[39m \u001b[38;5;28;43mself\u001b[39;49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43magent\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43manalyze\u001b[49m\u001b[43m(\u001b[49m\u001b[43msymbol\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m      7\u001b[0m     \u001b[38;5;28;01mreturn\u001b[39;00m {\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mmessage\u001b[39m\u001b[38;5;124m\"\u001b[39m: result\u001b[38;5;241m.\u001b[39mget(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124manalysis\u001b[39m\u001b[38;5;124m\"\u001b[39m, \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124m\"\u001b[39m)}\n",
-      "File \u001b[0;32m~/Python_Code/AI-Trading-Agent/trading_bot/agents/llm_roles.py:24\u001b[0m, in \u001b[0;36mMarketAnalystAgent.analyze\u001b[0;34m(self, symbol)\u001b[0m\n\u001b[1;32m     19\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mImportError\u001b[39;00m(\n\u001b[1;32m     20\u001b[0m         \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mopenai_client (and openai) must be available to use MarketAnalystAgent\u001b[39m\u001b[38;5;124m\"\u001b[39m\n\u001b[1;32m     21\u001b[0m     ) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mexc\u001b[39;00m\n\u001b[1;32m     23\u001b[0m prompt \u001b[38;5;241m=\u001b[39m \u001b[38;5;28mself\u001b[39m\u001b[38;5;241m.\u001b[39mprompt_template\u001b[38;5;241m.\u001b[39mformat(symbol\u001b[38;5;241m=\u001b[39msymbol)\n\u001b[0;32m---> 24\u001b[0m raw_response \u001b[38;5;241m=\u001b[39m \u001b[43mopenai_client\u001b[49m\u001b[38;5;241;43m.\u001b[39;49m\u001b[43mcall_openai\u001b[49m\u001b[43m(\u001b[49m\u001b[43mprompt\u001b[49m\u001b[43m)\u001b[49m\n\u001b[1;32m     26\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m {\n\u001b[1;32m     27\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124magent\u001b[39m\u001b[38;5;124m\"\u001b[39m: \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mMarketAnalystAgent\u001b[39m\u001b[38;5;124m\"\u001b[39m,\n\u001b[1;32m     28\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124msymbol\u001b[39m\u001b[38;5;124m\"\u001b[39m: symbol,\n\u001b[1;32m     29\u001b[0m     \u001b[38;5;124m\"\u001b[39m\u001b[38;5;124manalysis\u001b[39m\u001b[38;5;124m\"\u001b[39m: raw_response,\n\u001b[1;32m     30\u001b[0m }\n",
-      "File \u001b[0;32m~/Python_Code/AI-Trading-Agent/trading_bot/openai_client.py:72\u001b[0m, in \u001b[0;36mcall_openai\u001b[0;34m(prompt, temperature)\u001b[0m\n\u001b[1;32m     70\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mRuntimeError\u001b[39;00m(\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mOpenAI API rate limit exceeded\u001b[39m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mexc\u001b[39;00m\n\u001b[1;32m     71\u001b[0m \u001b[38;5;28;01mexcept\u001b[39;00m OpenAIError \u001b[38;5;28;01mas\u001b[39;00m exc:\n\u001b[0;32m---> 72\u001b[0m     \u001b[38;5;28;01mraise\u001b[39;00m \u001b[38;5;167;01mRuntimeError\u001b[39;00m(\u001b[38;5;124mf\u001b[39m\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mOpenAI API error: \u001b[39m\u001b[38;5;132;01m{\u001b[39;00mexc\u001b[38;5;132;01m}\u001b[39;00m\u001b[38;5;124m\"\u001b[39m) \u001b[38;5;28;01mfrom\u001b[39;00m\u001b[38;5;250m \u001b[39m\u001b[38;5;21;01mexc\u001b[39;00m\n\u001b[1;32m     74\u001b[0m \u001b[38;5;28;01mreturn\u001b[39;00m response\u001b[38;5;241m.\u001b[39mchoices[\u001b[38;5;241m0\u001b[39m]\u001b[38;5;241m.\u001b[39mmessage[\u001b[38;5;124m\"\u001b[39m\u001b[38;5;124mcontent\u001b[39m\u001b[38;5;124m\"\u001b[39m]\u001b[38;5;241m.\u001b[39mstrip()\n",
-      "\u001b[0;31mRuntimeError\u001b[0m: OpenAI API error: \n\nYou tried to access openai.ChatCompletion, but this is no longer supported in openai>=1.0.0 - see the README at https://github.com/openai/openai-python for the API.\n\nYou can run `openai migrate` to automatically upgrade your codebase to use the 1.0.0 interface. \n\nAlternatively, you can pin your installation to the old version, e.g. `pip install openai==0.28`\n\nA detailed migration guide is available here: https://github.com/openai/openai-python/discussions/742\n"
-     ]
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Trading Pipeline Demo\n",
+        "\n",
+        "Demonstrates running the pipeline for a date range and a single day."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "import sys, os\n",
+        "project_root = os.path.abspath(os.path.join(os.getcwd(), '..'))\n",
+        "if project_root not in sys.path:\n",
+        "    sys.path.append(project_root)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "from trading_bot.agents import MarketAnalystAgent, RiskAdvisorAgent, NewsSummarizerAgent\n",
+        "from trading_bot.coordinator import Coordinator\n",
+        "from trading_bot.pipeline import Pipeline\n",
+        "from trading_bot.storage import JSONStorage\n",
+        "from trading_bot.backtest import Backtester\n",
+        "from trading_bot.portfolio import Portfolio\n",
+        "\n",
+        "coord = Coordinator([MarketAnalystAgent(), RiskAdvisorAgent(), NewsSummarizerAgent()])\n",
+        "storage = JSONStorage()\n",
+        "backtester = Backtester()\n",
+        "portfolio = Portfolio()\n",
+        "pipe = Pipeline(coord, storage=storage, backtester=backtester, portfolio=portfolio)\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "range_result = pipe.run('TSLA', start_date='2025-01-01', end_date='2025-01-03')\n",
+        "range_result['files'], range_result['backtest']\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "single_result = pipe.run('TSLA', today='2025-01-02')\n",
+        "single_result['strategy'], single_result['files']\n"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "execution_count": null,
+      "outputs": [],
+      "source": [
+        "portfolio.total_pnl(), [p.__dict__ for p in portfolio.closed_positions()]\n"
+      ]
     }
-   ],
-   "source": [
-    "class Analyst:\n",
-    "    def __init__(self):\n",
-    "        self.agent = MarketAnalystAgent()\n",
-    "\n",
-    "    def respond(self, symbol, history):\n",
-    "        result = self.agent.analyze(symbol)\n",
-    "        return {\"message\": result.get(\"analysis\", \"\")}\n",
-    "\n",
-    "class Risk:\n",
-    "    def __init__(self):\n",
-    "        self.agent = RiskAdvisorAgent()\n",
-    "\n",
-    "    def respond(self, symbol, history):\n",
-    "        result = self.agent.assess(symbol)\n",
-    "        return {\"message\": result.get(\"assessment\", \"\")}\n",
-    "\n",
-    "class News:\n",
-    "    def __init__(self):\n",
-    "        self.agent = NewsSummarizerAgent()\n",
-    "\n",
-    "    def respond(self, symbol, history):\n",
-    "        result = self.agent.summarize(symbol)\n",
-    "        return {\"message\": result.get(\"summary\", \"\")}\n",
-    "\n",
-    "coordinator = Coordinator([Analyst(), Risk(), News()])\n",
-    "pipeline = Pipeline(coordinator)\n",
-    "result = pipeline.run(\"TSLA\")\n",
-    "result[\"final_decision\"]\n"
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": ".venv",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.12"
+    }
   },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5dc4ae4a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": ".venv",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.12"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
+  "nbformat": 4,
+  "nbformat_minor": 5
 }

--- a/tests/test_llm_roles.py
+++ b/tests/test_llm_roles.py
@@ -48,3 +48,12 @@ def test_news_summarizer_agent_returns_structured_data():
     assert data["headlines"] == ["h1"]
     assert data["agent"] == "NewsSummarizerAgent"
 
+
+def test_agent_handles_malformed_json():
+    fake = MagicMock(return_value="not json")
+    with patch("trading_bot.openai_client.call_llm", fake):
+        agent = MarketAnalystAgent()
+        data = agent.analyze("MSFT")
+    assert data["summary"] == ""
+    assert "error" in data
+

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, patch
 import types
 import sys
+import warnings
 
 from trading_bot import openai_client
 
@@ -19,6 +20,8 @@ def test_call_llm_falls_back_when_transformers_missing():
     dummy_module = types.SimpleNamespace(pipeline=MagicMock(side_effect=Exception("boom")))
     with patch.dict(sys.modules, {"transformers": dummy_module}):
         openai_client._GENERATOR = None
-        result = openai_client.call_llm("hi")
+        with warnings.catch_warnings(record=True) as w:
+            result = openai_client.call_llm("hi")
     assert result == "hi"
+    assert any("echo mode" in str(warning.message) for warning in w)
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from pathlib import Path
 from unittest.mock import MagicMock
 
 from trading_bot.coordinator import Coordinator
@@ -19,11 +20,12 @@ class DummyAgent:
 def test_coordinator_builds_strategy_summary():
     c = Coordinator([DummyAgent("A"), DummyAgent("B")])
     result = c.run("TSLA")
-    assert result["strategy_summary"] == "A for TSLA B for TSLA"
+    assert result["strategy_summary"]["A"]["summary"] == "A for TSLA"
+    assert result["strategy_summary"]["B"]["summary"] == "B for TSLA"
     assert len(result["conversation"]) == 2
 
 
-def test_pipeline_runs_range_and_backtests(tmp_path):
+def test_pipeline_runs_range_and_backtests(tmp_path, monkeypatch):
     coord = Coordinator([DummyAgent("A")])
     storage = JSONStorage(base_dir=tmp_path)
     backtester = Backtester()
@@ -32,9 +34,41 @@ def test_pipeline_runs_range_and_backtests(tmp_path):
 
     backtester.backtest = MagicMock(return_value={"net_return": 1})
 
+    import types
+    import pandas as pd
+    import sys
+
+    def fake_download(symbol, start, end, interval, progress=False):
+        idx = pd.date_range(start, end, freq="D")
+        return pd.DataFrame({"Close": [100.0 for _ in idx]}, index=idx)
+
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(download=fake_download))
+
     result = pipeline.run("TSLA", start_date="2024-01-01", end_date="2024-01-02")
 
     assert len(result["days"]) == 2
     assert Path(result["days"][0]["strategy_path"]).exists()
     backtester.backtest.assert_called_once()
+    assert len(portfolio.closed_positions()) == 2
+
+
+def test_pipeline_today_returns_paths(tmp_path, monkeypatch):
+    coord = Coordinator([DummyAgent("A")])
+    storage = JSONStorage(base_dir=tmp_path)
+    pipeline = Pipeline(coord, storage=storage)
+
+    import types
+    import pandas as pd
+    import sys
+
+    def fake_download(symbol, start, end, interval, progress=False):
+        idx = pd.date_range(start, end, freq="D")
+        return pd.DataFrame({"Close": [100.0 for _ in idx]}, index=idx)
+
+    monkeypatch.setitem(sys.modules, "yfinance", types.SimpleNamespace(download=fake_download))
+
+    result = pipeline.run("TSLA", today="2024-01-01")
+
+    assert "signal" in result["strategy"]
+    assert Path(result["files"]["strategy"]).exists()
 

--- a/tests/test_storage_portfolio_scheduler.py
+++ b/tests/test_storage_portfolio_scheduler.py
@@ -24,6 +24,7 @@ def test_portfolio_tracks_positions():
     pf.close_position(pos, 110.0, datetime(2024, 1, 2, 10, 0))
     assert pf.closed_positions() == [pos]
     assert pos.pnl() == 100.0
+    assert pf.total_pnl() == 100.0
 
 
 def test_scheduler_creates_jobs():

--- a/tests/test_strategy.py
+++ b/tests/test_strategy.py
@@ -1,0 +1,26 @@
+from trading_bot.strategy import compose_strategy
+
+
+def test_compose_strategy_generates_signal_and_followups():
+    agents = {
+        "MarketAnalystAgent": {
+            "summary": "bullish outlook",
+            "reasoning": "",
+            "market_trend": "bullish",
+        },
+        "RiskAdvisorAgent": {
+            "summary": "low risk",
+            "reasoning": "",
+            "risk_level": "low",
+        },
+        "NewsSummarizerAgent": {
+            "summary": "",
+            "reasoning": "",
+            "headlines": [],
+        },
+    }
+
+    strat = compose_strategy("TSLA", agents, strategy_date="2024-01-01")
+    assert strat["signal"] == "buy"
+    assert "bullish" in strat["rationale"].lower()
+    assert strat.get("follow_ups")

--- a/trading_bot/portfolio.py
+++ b/trading_bot/portfolio.py
@@ -62,5 +62,9 @@ class Portfolio:
     def closed_positions(self) -> List[Position]:
         return [p for p in self.positions if not p.is_open()]
 
+    def total_pnl(self) -> float:
+        """Return the realised profit and loss of all closed positions."""
+        return sum(p.pnl() or 0.0 for p in self.closed_positions())
+
 
 __all__ = ["Portfolio", "Position"]

--- a/trading_bot/strategy.py
+++ b/trading_bot/strategy.py
@@ -3,34 +3,54 @@
 from __future__ import annotations
 
 from datetime import date
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, List
 
 
 def compose_strategy(
     symbol: str, agent_data: Dict[str, Dict[str, Any]], *, strategy_date: Optional[str] = None
 ) -> Dict[str, Any]:
-    """Combine structured agent outputs into a simple action plan.
+    """Derive a trading signal from structured agent outputs.
 
-    Parameters
-    ----------
-    symbol:
-        The ticker symbol the strategy applies to.
-    agent_data:
-        Mapping of agent name to the structured dictionary each agent produced.
-    strategy_date:
-        ISO formatted date for the strategy.  Defaults to today's date.
+    The function inspects the ``market_trend`` from the analyst and the
+    ``risk_level`` from the risk advisor to produce a high level ``signal`` of
+    ``buy``, ``sell`` or ``hold``.  A human readable ``rationale`` summarises the
+    key factors.  If certain information is missing the function may include a
+    ``follow_ups`` list indicating areas that require more research.
     """
 
     strategy_date = strategy_date or date.today().isoformat()
     summary = " ".join(v.get("summary", "") for v in agent_data.values()).strip()
 
-    return {
+    trend = str(agent_data.get("MarketAnalystAgent", {}).get("market_trend", "")).lower()
+    risk = str(agent_data.get("RiskAdvisorAgent", {}).get("risk_level", "")).lower()
+
+    signal = "hold"
+    rationale: List[str] = []
+    follow_ups: List[str] = []
+
+    if "bull" in trend and risk not in {"high", "elevated"}:
+        signal = "buy"
+        rationale.append("Analyst reports bullish trend with acceptable risk")
+    elif "bear" in trend and risk in {"high", "elevated", "medium"}:
+        signal = "sell"
+        rationale.append("Bearish trend with noted risk")
+    else:
+        rationale.append("Mixed signals; hold position")
+
+    if not agent_data.get("NewsSummarizerAgent", {}).get("headlines"):
+        follow_ups.append("Review recent news for more context")
+
+    result: Dict[str, Any] = {
         "symbol": symbol,
         "date": strategy_date,
         "summary": summary,
         "details": agent_data,
-        "action": f"Review {symbol} with generated insights before trading.",
+        "signal": signal,
+        "rationale": " ".join(rationale),
     }
+    if follow_ups:
+        result["follow_ups"] = follow_ups
+    return result
 
 
 __all__ = ["compose_strategy"]


### PR DESCRIPTION
## Summary
- Demand JSON output from agents and handle malformed responses
- Aggregate agent results, compose trading signals, and persist per-day logs
- Add local model wrapper with warnings when falling back to echo mode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6892b8ea8a9c83328b324d20d0a896ef