### PR TITLE
Add explicit initializer to Pipeline and update usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,10 @@ For each configured symbol the pipeline performs:
        def respond(self, symbol, history):
            return {"message": NewsSummarizerAgent().summarize(symbol)["summary"]}
 
+   from trading_bot.storage import JSONStorage
+
    coordinator = Coordinator([Analyst(), Risk(), News()])
-   pipeline = Pipeline(coordinator)
+   pipeline = Pipeline(coordinator, storage=JSONStorage())
 
    result = pipeline.run("TSLA")
    print(result["conversation"])  # exchange between agents

--- a/trading_bot/pipeline.py
+++ b/trading_bot/pipeline.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, Iterable, List, Optional
 import warnings
@@ -16,14 +15,20 @@ from .backtest import Backtester
 from .portfolio import Portfolio
 
 
-@dataclass
 class Pipeline:
     """Coordinate agents and optionally backtest their combined strategy."""
 
-    coordinator: Coordinator
-    storage: JSONStorage
-    backtester: Optional[Backtester] = None
-    portfolio: Optional[Portfolio] = None
+    def __init__(
+        self,
+        coordinator: Coordinator,
+        storage: JSONStorage,
+        backtester: Optional[Backtester] = None,
+        portfolio: Optional[Portfolio] = None,
+    ) -> None:
+        self.coordinator = coordinator
+        self.storage = storage
+        self.backtester = backtester
+        self.portfolio = portfolio
 
     def _date_iter(self, start: str, end: str) -> Iterable[pd.Timestamp]:
         return pd.date_range(start, end, freq="D")


### PR DESCRIPTION
## Summary
- refactor `Pipeline` to accept coordinator, storage, backtester, and portfolio through an explicit initializer
- update README example to supply a JSONStorage instance when constructing `Pipeline`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6892c50a7f388332b8b8c61b6a42530d